### PR TITLE
fix directory creation for non-root users

### DIFF
--- a/pkg/chartsync/download.go
+++ b/pkg/chartsync/download.go
@@ -25,7 +25,7 @@ func makeChartPath(base string, source *helmfluxv1.RepoChartSource) string {
 	// filesystem; but we do need a stable, filesystem-friendly path
 	// to them that is based on the URL.
 	repoPath := filepath.Join(base, base64.URLEncoding.EncodeToString([]byte(source.CleanRepoURL())))
-	if err := os.MkdirAll(repoPath, os.FileMode(os.ModeDir+0660)); err != nil {
+	if err := os.MkdirAll(repoPath, 00750); err != nil {
 		panic(err)
 	}
 	filename := fmt.Sprintf("%s-%s.tgz", source.Name, source.Version)


### PR DESCRIPTION
When running as non-root, directory permissions have the execute bit stripped.  Maybe something to do with the octal mode wrapping due to the addition operation?  We can just use the octal mode directly to ensure we strip RWX off for other.  Note, the group sticky bit is set below from having `fsGroup` defined on the pod.

Current:
```
sh-4.2$ ls -l /tmp/
total 4
drw-r-S---. 2 1337 1337 4096 Aug 19 01:58 aHR0cH
```

Patched:
```
sh-4.2$ ls -l /tmp/
total 4
drwxr-s---. 2 helm-operator helm-operator 4096 Aug 19 02:02 aHR0cHM6Ly9k
```