### PR TITLE
Make update interval a configurable flag

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -198,8 +198,9 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.timeout`                                     | `git.timeout`                                        | Duration after which git operations time out
 | `git.ssh.secretName`                              | `None`                                               | The name of the kubernetes secret with the SSH private key, supercedes `git.secretName`
 | `git.ssh.known_hosts`                             | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
-| `chartsSyncInterval`                              | `3m`                                                 | Interval at which to check for changed charts
-| `workers`                                         | `None`                                               | (Experimental) amount of workers processing releases
+| `chartsSyncInterval`                              | `3m`                                                 | Period on which to reconcile the Helm releases with `HelmRelease` resources
+| `statusUpdateInterval`                            | `None`                                               | Period on which to update the Helm release status in `HelmRelease` resources
+| `workers`                                         | `None`                                               | Amount of workers processing releases
 | `logFormat`                                       | `fmt`                                                | Log format (fmt or json)
 | `logReleaseDiffs`                                 | `false`                                              | Helm operator should log the diff when a chart release diverges (possibly insecure)
 | `allowNamespace`                                  | `None`                                               | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -128,10 +128,13 @@ spec:
         args:
         {{- if .Values.logFormat }}
         - --log-format={{ .Values.logFormat }}
-        {{end}}
+        {{- end }}
         - --git-timeout={{ .Values.git.timeout }}
         - --git-poll-interval={{ .Values.git.pollInterval }}
         - --charts-sync-interval={{ .Values.chartsSyncInterval }}
+        {{- if .Values.statusUpdateInterval }}
+        - --status-update-interval={{ .Values.statusUpdateInterval }}
+        {{- end }}
         - --update-chart-deps={{ .Values.updateChartDeps }}
         - --log-release-diffs={{ .Values.logReleaseDiffs }}
         {{- if .Values.workers }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -19,8 +19,10 @@ updateChartDeps: true
 logFormat: fmt
 # Log the diff when a chart release diverges
 logReleaseDiffs: false
-# Interval at which to check for changed charts
+# Period on which to reconcile the Helm releases with `HelmRelease` resources
 chartsSyncInterval: "3m"
+# Period on which to update the Helm release status in `HelmRelease` resources
+statusUpdateInterval:
 # Amount of workers processing releases
 workers: 2
 
@@ -55,6 +57,7 @@ configureRepositories:
 
 # For charts stored in Git repos set the SSH private key secret
 git:
+  # Period on which to poll git chart sources for changes
   pollInterval: "5m"
   timeout: "20s"
   # Overrides for git over SSH. If you use your own git server, you

--- a/docs/references/operator.md
+++ b/docs/references/operator.md
@@ -17,24 +17,30 @@ take action accordingly.
 
 `helm-operator` requires setup and offers customization though a multitude of flags.
 
-| flag                      | default                       | purpose
-| ------------------------  | ----------------------------- | ---
-| --kubeconfig              |                               | Path to a kubeconfig. Only required if out-of-cluster.
-| --master                  |                               | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
-| --allow-namespace         |                               | If set, this limits the scope to a single namespace. if not specified, all namespaces will be watched.
+| Flag                        | Default                       | Purpose
+| --------------------------  | ----------------------------- | ---
+| `--log-format`              | `fmt`                         | Changes the logging format; `fmt` or `json`.
+| `--workers`                 | `1`                           | Amount of workers processing releases.
+| `--listen`                  | `:3030`                       | Listen address where `/metrics` and API will be served.
+| **Cluster configuration**
+| `--kubeconfig`              |                               | Path to a kubeconfig. Only required if out-of-cluster.
+| `--master`                  |                               | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
+| `--allow-namespace`         |                               | If set, this limits the scope to a single namespace. if not specified, all namespaces will be watched.
 | **Tiller options**
-| --tiller-ip               |                               | Tiller IP address. Only required if out-of-cluster.
-| --tiller-port             |                               | Tiller port.
-| --tiller-namespace        |                               | Tiller namespace. If not provided, the default is kube-system.
-| --tiller-tls-enable       | `false`                       | Enable TLS communication with Tiller. If provided, requires TLSKey and TLSCert to be provided as well.
-| --tiller-tls-verify       | `false`                       | Verify TLS certificate from Tiller. Will enable TLS communication when provided.
-| --tiller-tls-key-path     | `/etc/fluxd/helm/tls.key`     | Path to private key file used to communicate with the Tiller server.
-| --tiller-tls-cert-path    | `/etc/fluxd/helm/tls.crt`     | Path to certificate file used to communicate with the Tiller server.
-| --tiller-tls-ca-cert-path |                               | Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled.
-| --tiller-tls-hostname     |                               | The server name used to verify the hostname on the returned certificates from the Tiller server.
-| **repo chart changes** (none of these need overriding, usually)
-| --charts-sync-interval    | `3m`                          | Interval at which to check for changed charts.
-| --git-timeout             | `20s`                         | Duration after which git operations time out.
-| --git-poll-interval       | `5m`                          | Period on which to poll git chart sources for changes.
-| --log-release-diffs       | `false`                       | Log the diff when a chart release diverges. **Potentially insecure.**
-| --update-chart-deps       | `true`                        | Update chart dependencies before installing or upgrading a release.
+| `--tiller-ip`               |                               | Tiller IP address. Only required if out-of-cluster.
+| `--tiller-port`             |                               | Tiller port.
+| `--tiller-namespace`        |                               | Tiller namespace. If not provided, the default is kube-system.
+| `--tiller-tls-enable`       | `false`                       | Enable TLS communication with Tiller. If provided, requires TLSKey and TLSCert to be provided as well.
+| `--tiller-tls-verify`       | `false`                       | Verify TLS certificate from Tiller. Will enable TLS communication when provided.
+| `--tiller-tls-key-path`     | `/etc/fluxd/helm/tls.key`     | Path to private key file used to communicate with the Tiller server.
+| `--tiller-tls-cert-path`    | `/etc/fluxd/helm/tls.crt`     | Path to certificate file used to communicate with the Tiller server.
+| `--tiller-tls-ca-cert-path` |                               | Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled.
+| `--tiller-tls-hostname`     |                               | The server name used to verify the hostname on the returned certificates from the Tiller server.
+| **Reconciliation configuration**
+| `--charts-sync-interval`    | `3m`                          | Period on which to reconcile the Helm releases with `HelmRelease` resources
+| `--status-update-interval`  | `10s`                         | Period on which to update the Helm release status in `HelmRelease` resources
+| `--log-release-diffs`       | `false`                       | Log the diff when a chart release diverges. **Potentially insecure due to logging of secret values.**
+| **(Git sourced) chart changes** (none of these need overriding, usually)
+| `--git-timeout`             | `20s`                         | Duration after which git operations time out.
+| `--git-poll-interval`       | `5m`                          | Period on which to poll git chart sources for changes.
+| `--update-chart-deps`       | `true`                        | Update chart dependencies before installing or upgrading a release.

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	kube "k8s.io/client-go/kubernetes"
 	"k8s.io/helm/pkg/helm"
 	helmrelease "k8s.io/helm/pkg/proto/hapi/release"
 
@@ -30,14 +29,10 @@ import (
 	iflister "github.com/fluxcd/helm-operator/pkg/client/listers/helm.fluxcd.io/v1"
 )
 
-const period = 10 * time.Second
-
 type Updater struct {
 	hrClient   ifclientset.Interface
 	hrLister   iflister.HelmReleaseLister
-	kube       kube.Interface
 	helmClient *helm.Client
-	namespace  string
 }
 
 func New(hrClient ifclientset.Interface, hrLister iflister.HelmReleaseLister, helmClient *helm.Client) *Updater {
@@ -48,8 +43,8 @@ func New(hrClient ifclientset.Interface, hrLister iflister.HelmReleaseLister, he
 	}
 }
 
-func (u *Updater) Loop(stop <-chan struct{}, logger log.Logger) {
-	ticker := time.NewTicker(period)
+func (u *Updater) Loop(stop <-chan struct{}, interval time.Duration, logger log.Logger) {
+	ticker := time.NewTicker(interval)
 	var logErr error
 
 bail:


### PR DESCRIPTION
As in clusters that have many `HelmRelease` resources, the hardcoded
default would put too much pressure on `etcd` due to Tiller collecting
information. By making the interval a configurable flag, people can
tweak the value to find the right balance of (non) pressure and
observability.

Image for testing available as `hiddeco/helm-operator:update-interval-conf-9a48227b`