### PR TITLE
Add ability to specify multiple ssh keys

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -198,6 +198,8 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `git.timeout`                                     | `git.timeout`                                        | Duration after which git operations time out
 | `git.ssh.secretName`                              | `None`                                               | The name of the kubernetes secret with the SSH private key, supercedes `git.secretName`
 | `git.ssh.known_hosts`                             | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
+| `git.ssh.configMapName`                           | `None`                                               | The name of a kubernetes config map containing the ssh config
+| `git.ssh.configMapKey`                            | `config`                                             | The name of the key in the kubernetes config map specified above
 | `chartsSyncInterval`                              | `3m`                                                 | Period on which to reconcile the Helm releases with `HelmRelease` resources
 | `statusUpdateInterval`                            | `None`                                               | Period on which to update the Helm release status in `HelmRelease` resources
 | `workers`                                         | `None`                                               | Amount of workers processing releases

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       volumes:
       {{- if .Values.git.ssh.known_hosts }}
-      - name: sshdir
+      - name: sshknownhosts
         configMap:
           name: {{ template "helm-operator.fullname" . }}-ssh-config
           defaultMode: 0600
@@ -43,6 +43,15 @@ spec:
       - name: git-config
         secret:
           secretName: {{ include "git.config.secretName" . }}
+          defaultMode: 0400
+      {{- end }}
+      {{- if .Values.git.ssh.configMapName }}
+      - name: sshconfig
+        configMap:
+          name: {{ .Values.git.ssh.configMapName }}
+          items:
+            - key: {{ .Values.git.ssh.configMapKey | default "config" }}
+              path: config
           defaultMode: 0400
       {{- end }}
       - name: git-key
@@ -93,9 +102,14 @@ spec:
           timeoutSeconds: 5
         volumeMounts:
         {{- if .Values.git.ssh.known_hosts }}
-        - name: sshdir
+        - name: sshknownhosts
           mountPath: /root/.ssh/known_hosts
           subPath: known_hosts
+          readOnly: true
+        {{- end }}
+        {{- if .Values.git.ssh.configMapName }}
+        - name: sshconfig
+          mountPath: /root/.ssh/
           readOnly: true
         {{- end }}
         {{- if .Values.git.config.enabled }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -70,6 +70,23 @@ git:
     # set the secret name (helm-ssh) below
     secretName: ""
     known_hosts: ""
+    # You may want to configure access to multiple repositories via multiple deploy keys
+    # flux-helm-operator is configured in /etc/ssh/ssh_config to use for all hosts the file /etc/fluxd/ssh/identity
+    # this file is mounted from the above secret
+    # all entries in the secret are mounted in the same place /etc/fluxd/ssh/
+    # so we can add more entries by providing this config map with a key of config that refer to other files in /etc/fluxd/ssh/
+    # e.g. in the above secret create another key for example myprivatehelmrepo
+    # in the below config map create a key config and input the following
+    #
+    # Host *
+    # StrictHostKeyChecking yes
+    # IdentityFile /etc/fluxd/ssh/identity
+    # IdentityFile /var/fluxd/keygen/identity
+    # IdentityFile /var/fluxd/keygen/myprivatehelmrepo
+    # LogLevel error
+    #
+    # add the public key to the other repository as a deploy key and enjoy
+    configMapName: ""
   # Global Git configuration See https://git-scm.com/docs/git-config for more details.
   config:
     enabled: false


### PR DESCRIPTION
If applied this commit will enable the ability to add more than one ssh
key so that git can authenticate with multiple private repositories
This is achieved by loading of the ssh config via a provided configmap
(git.ssh.configMapName) this can be used to specify additional identity
files; the additional keys can be provided by adding keys to the
existing secert (git.ssh.secretName)

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
