### PR TITLE
Add public Helm repos to the default config 

### DIFF
--- a/docker/helm-repositories.yaml
+++ b/docker/helm-repositories.yaml
@@ -8,3 +8,43 @@ repositories:
   password: ""
   url: https://kubernetes-charts.storage.googleapis.com
   username: ""
+- caFile: ""
+  cache: /var/fluxd/helm/repository/cache/fluxcd-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: fluxcd
+  password: ""
+  url: https://charts.fluxcd.io
+  username: ""
+- caFile: ""
+  cache: /var/fluxd/helm/repository/cache/flagger-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: flagger
+  password: ""
+  url: https://flagger.app
+  username: ""
+- caFile: ""
+  cache: /var/fluxd/helm/repository/cache/bitnami-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: bitnami
+  password: ""
+  url: https://charts.bitnami.com/bitnami
+  username: ""
+- caFile: ""
+  cache: /var/fluxd/helm/repository/cache/azure-marketplace-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: azure-marketplace
+  password: ""
+  url: https://marketplace.azurecr.io/helm/v1/repo
+  username: ""
+- caFile: ""
+  cache: /var/fluxd/helm/repository/cache/openfaas-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: openfaas
+  password: ""
+  url: https://openfaas.github.io/faas-netes
+  username: ""


### PR DESCRIPTION
Add bitnami, azure, fluxcd, flagger and openfaas Helm repositories to the default config. 