### PR TITLE
Make `OwnedByHelmRelease` default to `true`

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -344,7 +344,7 @@ func (r *Release) OwnedByHelmRelease(release *hapi_release.Release, hr helmfluxv
 		}
 	}
 
-	return false
+	return true
 }
 
 // annotateResources annotates each of the resources created (or updated)


### PR DESCRIPTION
To work around an edge case scenarios some users have reported where
the release manifest does not result in any resources (or they are
all skipped), and the `HelmRelease` is therefore falsely marked as
'not being owned by'.

This should all be refactored to an `ownerReference`, so that we can
make use of Kubernetes' garbage collection functionalities[1] and no
longer reinvent the wheel.

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents