### PR TITLE
Make release build cope with `v` prefixed tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,21 @@ jobs:
       - deploy:
           name: Maybe push release image
           command: |
-            if echo "${CIRCLE_TAG}" | grep -Eq "^[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"; then
+            if echo "${CIRCLE_TAG}" | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"; then
               echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
-              docker push "docker.io/fluxcd/helm-operator:${CIRCLE_TAG}"
+              docker push "docker.io/fluxcd/helm-operator:$(docker/image-tag)"
+
+              # Republish tag _without_ the `v` prefix, for historical reasons
+              git config --global user.email fluxcdbot@users.noreply.github.com
+              git config --global user.name fluxcdbot
+
+              REPOSITORY="https://fluxcdbot:${GITHUB_TOKEN}@github.com/fluxcd/helm-operator.git"
+              git remote set-url origin ${REPOSITORY}
+
+              # Remove `v` prefix using bash string manipulation
+              VLESS_TAG=${CIRCLE_TAG#v}
+              git tag ${VLESS_TAG} $(git rev-list -n1 ${CIRCLE_TAG})
+              git push origin ${VLESS_TAG}
             fi
 
   helm:
@@ -133,7 +145,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?/
+              only: /v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?/
   release-helm:
     jobs:
       - helm:

--- a/docker/image-tag
+++ b/docker/image-tag
@@ -10,13 +10,13 @@ if [ "${1:-}" = '--show-diff' ]; then
 fi
 
 # If a tagged version, just print that tag
-HEAD_TAGS=$(git tag --points-at HEAD)
-if [ -n "${HEAD_TAGS}" ] ; then
-    # remove helm- prefix from helm-op release name
-    if echo "${HEAD_TAGS}" | grep -Eq "helm-[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
-      HEAD_TAGS=$(echo "$HEAD_TAGS" | cut -c 6-)
+HEAD_TAG=$(git tag --points-at HEAD | head -n1)
+if [ -n "${HEAD_TAG}" ] ; then
+    # remove `v` prefix from release name
+    if echo "${HEAD_TAG}" | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"; then
+      HEAD_TAG=$(echo "$HEAD_TAG" | cut -c 2-)
     fi
-	echo ${HEAD_TAGS}
+	echo ${HEAD_TAG}
 	exit 0
 fi
 


### PR DESCRIPTION
As we want to publish our images without the `v` prefix, some
modifications have been made to the `docker/image-tag` helper script to
remove the `v` prefix from the calculated tag.

In addition, the amount of tags it returns has been limited to one, as
multiple tags will make the build fail due to

`-ldflags "-X main.version=<tagA> <tagB>"`

not being a valid argument.
