### PR TITLE
Add EKS charts to repositories

### DIFF
--- a/docker/helm-repositories.yaml
+++ b/docker/helm-repositories.yaml
@@ -48,3 +48,11 @@ repositories:
   password: ""
   url: https://openfaas.github.io/faas-netes
   username: ""
+- caFile: ""
+  cache: /var/fluxd/helm/repository/cache/eks-index.yaml
+  certFile: ""
+  keyFile: ""
+  name: eks
+  password: ""
+  url: https://aws.github.io/eks-charts
+  username: ""


### PR DESCRIPTION
Add the [EKS charts](https://github.com/aws/eks-charts) to the repositories file.
