### PR TITLE
Showing chart name and version in the kubectl get hr

### DIFF
--- a/deploy/flux-helm-release-crd.yaml
+++ b/deploy/flux-helm-release-crd.yaml
@@ -19,6 +19,12 @@ spec:
     - JSONPath: .status.releaseStatus
       name: Status
       type: string
+    - JSONPath: .spec.chart.name
+      name: Chart
+      type: string
+    - JSONPath: .spec.chart.version
+      name: Version
+      type: string    
     - JSONPath: .status.conditions[?(@.type=="Released")].message
       name: Message
       type: string


### PR DESCRIPTION
I found the `kubectl get hr ` showing the chart and version information at the initial view itself. For usual debugging the chart and the version currently synced from the git would be easier to understand.
