### PR TITLE
Allow for deploying Tiller as a sidecar.

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -207,6 +207,10 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `logReleaseDiffs`                                 | `false`                                              | Helm operator should log the diff when a chart release diverges (possibly insecure)
 | `allowNamespace`                                  | `None`                                               | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched
 | `tillerNamespace`                                 | `kube-system`                                        | Namespace in which the Tiller server can be found
+| `tillerSidecar.enabled`                           | `false`                                              | Whether to deploy Tiller as a sidecar (and listening on `localhost` only).
+| `tillerSidecar.image.repository`                  | `gcr.io/kubernetes-helm/tiller`                      | Image repository to use for the Tiller sidecar.
+| `tillerSidecar.image.tag`                         | `v2.14.3`                                            | Image tag to use for the Tiller sidecar.
+| `tillerSidecar.storage`                           | `secret`                                             | Storage engine to use for the Tiller sidecar.
 | `tls.enable`                                      | `false`                                              | Enable TLS for communicating with Tiller
 | `tls.verify`                                      | `false`                                              | Verify the Tiller certificate, also enables TLS when set to true
 | `tls.secretName`                                  | `helm-client-certs`                                  | Name of the secret containing the TLS client certificates for communicating with Tiller

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -159,6 +159,10 @@ spec:
         {{- else if .Values.allowNamespace }}
         - --allow-namespace={{ .Values.allowNamespace }}
         {{- end }}
+        {{- if .Values.tillerSidecar.enabled }}
+        - --tiller-ip=localhost
+        - --tiller-port=44134
+        {{- else }}
         {{- if .Values.tillerHost }}
         - --tiller-ip={{ .Values.tillerHost }}
         - --tiller-port={{ .Values.tillerPort }}
@@ -177,12 +181,42 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- end }}
       {{- if .Values.extraEnvs }}
         env:
 {{ toYaml .Values.extraEnvs | indent 8 }}
       {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+      {{- if .Values.tillerSidecar.enabled }}
+      - name: tiller
+        image: "{{ .Values.tillerSidecar.image.repository }}:{{ .Values.tillerSidecar.image.tag }}"
+        args:
+        - --listen=localhost:44134
+        - --probe-listen=:44135
+        - --storage={{ .Values.tillerSidecar.storage }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 44135
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        env:
+        - name: TILLER_NAMESPACE
+          value: {{ .Release.Namespace }}
+        - name: TILLER_HISTORY_MAX
+          value: "10"
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -42,6 +42,16 @@ tls:
   caContent: ""
   hostname: ""
 
+# ADVANCED: Allow for deploying Tiller as a sidecar (restricted to 'localhost' for security reasons).
+# When enabled, either .clusterRole.create should be true or .clusterRole.name should be set to the name of a cluster role granting the required privileges.
+# Please make extra sure you know what you are doing before enabling this. :)
+tillerSidecar:
+  enabled: false
+  image:
+    repository: gcr.io/kubernetes-helm/tiller
+    tag: v2.14.3
+  storage: secret
+
 # For charts stored in Helm repositories other than stable
 # mount repositories.yaml configuration in a volume
 configureRepositories:


### PR DESCRIPTION
In this PR I propose adding support in the Helm chart for deploying Tiller as a sidecar (restricted to `localhost`). This is inspired by a [comment](https://github.com/fluxcd/flux/issues/1420#issuecomment-426759442) by @justinbarrick, and I believe that, although possibly being an advanced scenario, would be of use for some people ( like me 🙂 ). Tiller is eventually going away, but I believe this may be a useful addition while #8 isn't finished. I've kept this new feature undocumented because it's probably a good idea to "restrict" access to it to whoever finds themselves in need of fiddling with `values.yaml` ( and also because I am not quite sure this will get accepted as a feature 🙂 ).