### PR TITLE
Add flag to specify alternative default git ref

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -196,6 +196,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `updateChartDeps`                                 | `true`                                               | Update dependencies for charts
 | `git.pollInterval`                                | `git.pollInterval`                                   | Period on which to poll git chart sources for changes
 | `git.timeout`                                     | `git.timeout`                                        | Duration after which git operations time out
+| `git.defaultRef`                                  | `master`                                             | Ref to clone chart from if ref is unspecified in a HelmRelease
 | `git.ssh.secretName`                              | `None`                                               | The name of the kubernetes secret with the SSH private key, supercedes `git.secretName`
 | `git.ssh.known_hosts`                             | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
 | `git.ssh.configMapName`                           | `None`                                               | The name of a kubernetes config map containing the ssh config

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -145,6 +145,9 @@ spec:
         {{- end }}
         - --git-timeout={{ .Values.git.timeout }}
         - --git-poll-interval={{ .Values.git.pollInterval }}
+        {{- if .Values.git.defaultRef }}
+        - --git-default-ref={{ .Values.git.defaultRef }}
+        {{- end }}
         - --charts-sync-interval={{ .Values.chartsSyncInterval }}
         {{- if .Values.statusUpdateInterval }}
         - --status-update-interval={{ .Values.statusUpdateInterval }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -70,6 +70,8 @@ git:
   # Period on which to poll git chart sources for changes
   pollInterval: "5m"
   timeout: "20s"
+  # Ref to clone chart from if ref is unspecified in a HelmRelease
+  defaultRef: "master"
   # Overrides for git over SSH. If you use your own git server, you
   # will likely need to provide a host key for it in this field.
   ssh:

--- a/docs/references/helmrelease-custom-resource.md
+++ b/docs/references/helmrelease-custom-resource.md
@@ -75,9 +75,10 @@ spec:
 ```
 
 In this case, the git repo will be cloned, and the chart will be
-released from the ref given (which defaults to `master`, if not
-supplied). Commits to the git repo may result in releases, if they
-update the chart at the path given.
+released from the ref given. If not supplied, the operator uses
+the value specified by the `--git-default-ref` flag (which
+defaults to `master`). Commits to the git repo may result in releases,
+if they update the chart at the path given.
 
 Note that you will usually need to provide an SSH key to grant access
 to the git repository. The example deployment shows how to mount a

--- a/pkg/apis/helm.fluxcd.io/v1/types.go
+++ b/pkg/apis/helm.fluxcd.io/v1/types.go
@@ -117,13 +117,11 @@ type GitChartSource struct {
 	SkipDepUpdate bool `json:"skipDepUpdate,omitempty"`
 }
 
-// DefaultGitRef is the ref assumed if the Ref field is not given in
-// a GitChartSource
-const DefaultGitRef = "master"
-
-func (s GitChartSource) RefOrDefault() string {
+// RefOrDefault returns the configured ref of the chart source. If the chart source
+// does not specify a ref, the provided default is used instead.
+func (s GitChartSource) RefOrDefault(defaultGitRef string) string {
 	if s.Ref == "" {
-		return DefaultGitRef
+		return defaultGitRef
 	}
 	return s.Ref
 }

--- a/pkg/apis/helm.fluxcd.io/v1/types_test.go
+++ b/pkg/apis/helm.fluxcd.io/v1/types_test.go
@@ -50,3 +50,29 @@ func TestHelmValues(t *testing.T) {
 		assert.Exactly(t, tc.expectedOriginal, tc.original, "original was mutated. test case: %d", i)
 	}
 }
+
+func TestRefOrDefault(t *testing.T) {
+	testCases := []struct {
+		chartSource      GitChartSource
+		potentialDefault string
+		expected         string
+	}{
+		{
+			chartSource: GitChartSource{
+				Ref: "master",
+			},
+			potentialDefault: "dev",
+			expected:         "master",
+		},
+		{
+			chartSource:      GitChartSource{},
+			potentialDefault: "dev",
+			expected:         "dev",
+		},
+	}
+
+	for _, tc := range testCases {
+		got := tc.chartSource.RefOrDefault(tc.potentialDefault)
+		assert.Equal(t, tc.expected, got)
+	}
+}

--- a/pkg/chartsync/chartsync.go
+++ b/pkg/chartsync/chartsync.go
@@ -89,6 +89,7 @@ type Config struct {
 	UpdateDeps      bool
 	GitTimeout      time.Duration
 	GitPollInterval time.Duration
+	GitDefaultRef   string
 }
 
 func (c Config) WithDefaults() Config {
@@ -195,7 +196,7 @@ func (chs *ChartChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *syn
 					// schedule an upgrade for every HelmRelease that
 					// makes use of the mirror
 					for _, hr := range resources {
-						ref := hr.Spec.ChartSource.GitChartSource.RefOrDefault()
+						ref := hr.Spec.ChartSource.GitChartSource.RefOrDefault(chs.config.GitDefaultRef)
 						path := hr.Spec.ChartSource.GitChartSource.Path
 						releaseName := hr.ReleaseName()
 
@@ -507,7 +508,7 @@ func (chs *ChartChangeSync) getGitChartSource(hr helmfluxv1.HelmRelease) (string
 	// Validate the clone we have for the release is the same as
 	// is being referenced in the chart source.
 	if ok {
-		ok = chartClone.remote == chartSource.GitURL && chartClone.ref == chartSource.RefOrDefault()
+		ok = chartClone.remote == chartSource.GitURL && chartClone.ref == chartSource.RefOrDefault(chs.config.GitDefaultRef)
 		if !ok {
 			if chartClone.export != nil {
 				chartClone.export.Clean()


### PR DESCRIPTION
Add the `--git-default-chart-ref` flag which enables the modification
of the ref used to clone a chart if the `.spec.git.ref` field is
unspecified. The original default of `master` is maintained.

Related issue: https://github.com/fluxcd/helm-operator/issues/80

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
