### PR TITLE
Add release count metric

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,7 @@ github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod 
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
+github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=

--- a/pkg/release/metrics.go
+++ b/pkg/release/metrics.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-kit/kit/metrics/prometheus"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -27,6 +28,15 @@ var (
 	}, []string{LabelAction, LabelDryRun, LabelSuccess, LabelNamespace, LabelReleaseName})
 )
 
+var (
+	releasesPerformed = promauto.NewCounter(stdprometheus.CounterOpts{
+		Namespace: "flux",
+		Subsystem: "helm_operator",
+		Name:      "releases_performed_total",
+		Help:      "Total number of releases performed.",
+	})
+)
+
 func ObserveRelease(start time.Time, action Action, dryRun, success bool, namespace, releaseName string) {
 	releaseDuration.With(
 		LabelAction, string(action),
@@ -35,4 +45,8 @@ func ObserveRelease(start time.Time, action Action, dryRun, success bool, namesp
 		LabelNamespace, namespace,
 		LabelReleaseName, releaseName,
 	).Observe(time.Since(start).Seconds())
+}
+
+func RecordRelease() {
+	go releasesPerformed.Inc()
 }

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -28,8 +28,8 @@ import (
 	hapi_release "k8s.io/helm/pkg/proto/hapi/release"
 	helmutil "k8s.io/helm/pkg/releaseutil"
 
-	helmfluxv1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
 	fluxk8s "github.com/fluxcd/flux/pkg/cluster/kubernetes"
+	helmfluxv1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
 )
 
 type Action string
@@ -228,6 +228,7 @@ func (r *Release) Install(chartPath, releaseName string, hr helmfluxv1.HelmRelea
 		}
 		if !opts.DryRun {
 			r.annotateResources(res.Release, hr)
+			RecordRelease()
 		}
 		return res.Release, checksum, err
 	case UpgradeAction:
@@ -248,6 +249,7 @@ func (r *Release) Install(chartPath, releaseName string, hr helmfluxv1.HelmRelea
 		}
 		if !opts.DryRun {
 			r.annotateResources(res.Release, hr)
+			RecordRelease()
 		}
 		return res.Release, checksum, err
 	default:


### PR DESCRIPTION
As we want to know the number of relases performed by the Helm
Operator, a counter metric (`releases_performed_total`) was added
to keep track of this number.
Both installations and upgrades increase the counter.

**Examples of how to use the metric in a PromQL query:**
Using the metric "as is"
(`flux_helm_operator_releases_performed_total`) returns the total
number of releases since the Helm Operator was started.

To get the total number of releases performed during the last
7 days:
`sum(max_over_time(flux_helm_operator_releases_performed_total[7d]))`

Co-authored-by: larsroger <larsroger@users.noreply.github.com>

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
