### PR TITLE
remove replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,18 @@
 module github.com/fluxcd/helm-operator
 
-go 1.12
+go 1.13
+
+// Transitive requirement from flux: remove when https://github.com/docker/distribution/pull/2905 is released.
+replace github.com/docker/distribution => github.com/2opremio/distribution v0.0.0-20190419185413-6c9727e5e5de
+
+// Force downgrade because of a trasitive upgrade.
+//
+// github.com/fluxcd/helm-operator
+// +-> github.com/fluxcd/flux@v1.15.0
+//     +-> github.com/fluxcd/helm-operator@v1.0.0-rc1
+//         +-> github.com/weaveworks/flux@v0.0.0-20190729133003-c78ccd3706b5
+//             +-> k8s.io/code-generator@v0.0.0-20190511023357-639c964206c2
+replace k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190311093542-50b561225d70
 
 require (
 	github.com/fluxcd/flux v1.15.0
@@ -15,32 +27,11 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
-	k8s.io/api v0.0.0-20190313235455-40a48860b5ab
-	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
+	k8s.io/api v0.0.0-20190708174958-539a33f6e817 // kubernetes-1.14.4
+	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d // kubernetes-1.14.4
 	k8s.io/client-go v11.0.0+incompatible
-	k8s.io/code-generator v0.0.0-20190511023357-639c964206c2
+	k8s.io/code-generator v0.0.0-20190511023357-639c964206c2 // kubernetes-1.14.4
 	k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab // indirect
 	k8s.io/helm v2.14.3+incompatible
 	k8s.io/klog v0.3.3
-)
-
-// this is required to avoid
-//    github.com/docker/distribution@v0.0.0-00010101000000-000000000000: unknown revision 000000000000
-// because flux also replaces it, and we depend on flux
-replace github.com/docker/distribution => github.com/2opremio/distribution v0.0.0-20190419185413-6c9727e5e5de
-
-// The following pin these libs to `kubernetes-1.14.4` (by initially
-// giving the version as that tag, and letting go mod fill in its idea of
-// the version).
-// The libs are thereby kept compatible with client-go v11, which is
-// itself compatible with Kubernetes 1.14.
-// The helm package is pinned here to avoid pulling old versions of Helm due to Flux circular dependency
-replace (
-	k8s.io/api => k8s.io/api v0.0.0-20190708174958-539a33f6e817
-	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
-	k8s.io/apiserver => k8s.io/apiserver v0.0.0-20190708180123-608cd7da68f7
-	k8s.io/client-go => k8s.io/client-go v11.0.0+incompatible
-	k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190311093542-50b561225d70
-	k8s.io/component-base => k8s.io/component-base v0.0.0-20190708175518-244289f83105
-	k8s.io/helm => k8s.io/helm v2.14.3+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+k8s.io/api v0.0.0-20190313235455-40a48860b5ab/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/api v0.0.0-20190708174958-539a33f6e817 h1:V6YPTc5fSnwv7EBjx6es9VyAki/6bqK4M3ECA6WwfBk=
 k8s.io/api v0.0.0-20190708174958-539a33f6e817/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apiextensions-apiserver v0.0.0-20190315093550-53c4693659ed h1:rCteec//ELIjZMfjIGQbVtZooyaofqDJwsmWwWKItNs=
@@ -393,6 +394,7 @@ k8s.io/code-generator v0.0.0-20190311093542-50b561225d70 h1:lgPp615xLHxN84RBd+vi
 k8s.io/code-generator v0.0.0-20190311093542-50b561225d70/go.mod h1:MYiN+ZJZ9HkETbgVZdWw2AsuAi9PZ4V80cwfuf2axe8=
 k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab h1:j4L8spMe0tFfBvvW6lrc0c+Ql8+nnkcV3RYfi3eSwGY=
 k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/helm v2.13.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/helm v2.14.3+incompatible h1:uzotTcZXa/b2SWVoUzM1xiCXVjI38TuxMujS/1s+3Gw=
 k8s.io/helm v2.14.3+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=


### PR DESCRIPTION
go.mod contains many replace entries that all consumers must include to
import logic. These are cancerous and tend to make consumers builds
difficult or outright fail. All have been removed, except for the one
required by flux. This entry, while retained, has converted into a noop
and should be removed when fluxcd/flux#2590 is fixed.