### PR TITLE
pkg/chartsync: only use official flux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
-	github.com/weaveworks/flux v0.0.0-20190729133003-c78ccd3706b5
 	k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.0+incompatible

--- a/pkg/chartsync/chartsync.go
+++ b/pkg/chartsync/chartsync.go
@@ -55,13 +55,13 @@ import (
 	hapi_chart "k8s.io/helm/pkg/proto/hapi/chart"
 	hapi_release "k8s.io/helm/pkg/proto/hapi/release"
 
+	"github.com/fluxcd/flux/pkg/git"
 	helmop "github.com/fluxcd/helm-operator/pkg"
 	helmfluxv1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
 	ifclientset "github.com/fluxcd/helm-operator/pkg/client/clientset/versioned"
 	iflister "github.com/fluxcd/helm-operator/pkg/client/listers/helm.fluxcd.io/v1"
 	"github.com/fluxcd/helm-operator/pkg/release"
 	"github.com/fluxcd/helm-operator/pkg/status"
-	"github.com/weaveworks/flux/git"
 )
 
 const (


### PR DESCRIPTION
It appears in a previous refactor, after the repo name migration, that
one remaining reference to github.com/weaveworks/flux was left in
source. This change fixes that, and removes the dependency from the
go.mod.