### PR TITLE
Do not prefix image tag in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ jobs:
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "helm-v3-dev" ]; then
               echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
 
-              docker tag "docker.io/fluxcd/helm-operator:$(docker/image-tag)" "docker.io/fluxcd/helm-operator-prerelease:helm-v3-$(docker/image-tag)"
-              docker push "docker.io/fluxcd/helm-operator-prerelease:helm-v3-$(docker/image-tag)"
+              docker tag "docker.io/fluxcd/helm-operator:$(docker/image-tag)" "docker.io/fluxcd/helm-operator-prerelease:$(docker/image-tag)"
+              docker push "docker.io/fluxcd/helm-operator-prerelease:$(docker/image-tag)"
             fi
       - deploy:
           name: Maybe push release image


### PR DESCRIPTION
As this was actually already done by the script we use to generate the image tag.