### PR TITLE
Proper support for enabling Helm client versions

### DIFF
--- a/pkg/apis/helm.fluxcd.io/v1/types.go
+++ b/pkg/apis/helm.fluxcd.io/v1/types.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/weaveworks/flux/resource"
 
 	"github.com/fluxcd/helm-operator/pkg/helm/v2"
-	"github.com/fluxcd/helm-operator/pkg/helm/v3"
 )
 
 // +genclient
@@ -189,14 +187,12 @@ type HelmReleaseSpec struct {
 	Rollback Rollback `json:"rollback,omitempty"`
 }
 
-func (hr HelmRelease) GetHelmVersion() string {
+func (hr HelmRelease) GetHelmVersion(defaultVersion string) string {
 	if hr.Spec.HelmVersion != "" {
 		return hr.Spec.HelmVersion
 	}
-	// TODO(hidde): figure out a way to make this configurable
-	// through flags, for now, this will do just fine.
-	if v, ok := os.LookupEnv("HELM_VERSION"); ok && (v == v2.VERSION || v == v3.VERSION) {
-		return v
+	if defaultVersion != "" {
+		return defaultVersion
 	}
 	return v2.VERSION
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -31,4 +31,5 @@ type Client interface {
 	Rollback(releaseName string, opts RollbackOptions) (*Release, error)
 	DependencyUpdate(chartPath string) error
 	Uninstall(releaseName string, opts UninstallOptions) error
+	Version() string
 }

--- a/pkg/helm/v2/helm.go
+++ b/pkg/helm/v2/helm.go
@@ -36,6 +36,10 @@ type HelmV2 struct {
 	logger log.Logger
 }
 
+func (h *HelmV2) Version() string {
+	return VERSION
+}
+
 // getVersion retrieves the Tiller version. This is a _V2 only_  method
 // and used internally during the setup of the client.
 func (h *HelmV2) getVersion() (string, error) {

--- a/pkg/helm/v3/helm.go
+++ b/pkg/helm/v3/helm.go
@@ -50,6 +50,10 @@ func New(logger log.Logger, kubeConfig *rest.Config) helm.Client {
 	}
 }
 
+func (h *HelmV3) Version() string {
+	return VERSION
+}
+
 // initActionConfig initializes the configuration for the action,
 // like the namespace it should be executed in and the storage driver.
 func initActionConfig(kubeConfig *rest.Config, opts HelmOptions) (*action.Configuration, func(), error) {

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -88,7 +88,7 @@ func (r *Release) Sync(client helm.Client, hr *v1.HelmRelease) (rHr *v1.HelmRele
 	}(time.Now())
 	defer status.SetObservedGeneration(r.helmReleaseClient.HelmReleases(hr.Namespace), *hr, hr.Generation)
 
-	logger := releaseLogger(r.logger, hr)
+	logger := releaseLogger(r.logger, client, hr)
 
 	// Ensure we have the chart for the release, construct the path
 	// to the chart, and record the revision.
@@ -257,7 +257,7 @@ func (r *Release) Sync(client helm.Client, hr *v1.HelmRelease) (rHr *v1.HelmRele
 // Uninstalls removes the Helm release for the given `v1.HelmRelease`,
 // and the git chart source if present.
 func (r *Release) Uninstall(client helm.Client, hr *v1.HelmRelease) {
-	logger := releaseLogger(r.logger, hr)
+	logger := releaseLogger(r.logger, client, hr)
 
 	if err := client.Uninstall(hr.GetReleaseName(), helm.UninstallOptions{
 		Namespace:   hr.GetTargetNamespace(),
@@ -351,11 +351,11 @@ func shouldSync(logger log.Logger, client helm.Client, hr *v1.HelmRelease, curRe
 
 // releaseLogger returns a logger in the context of the given
 // HelmRelease (that being, with metadata included).
-func releaseLogger(logger log.Logger, hr *v1.HelmRelease) log.Logger {
+func releaseLogger(logger log.Logger, client helm.Client, hr *v1.HelmRelease) log.Logger {
 	return log.With(logger,
 		"release", hr.GetReleaseName(),
 		"targetNamespace", hr.GetTargetNamespace(),
 		"resource", hr.ResourceID().String(),
-		"helmVersion", hr.GetHelmVersion(),
+		"helmVersion", client.Version(),
 	)
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -36,14 +36,15 @@ type Updater struct {
 	hrLister    iflister.HelmReleaseLister
 	kube        kube.Interface
 	helmClients *helm.Clients
-	namespace   string
+	defaultHelmVersion string
 }
 
-func New(hrClient ifclientset.Interface, hrLister iflister.HelmReleaseLister, helmClients *helm.Clients) *Updater {
+func New(hrClient ifclientset.Interface, hrLister iflister.HelmReleaseLister, helmClients *helm.Clients, defaultHelmVersion string) *Updater {
 	return &Updater{
-		hrClient:    hrClient,
-		hrLister:    hrLister,
-		helmClients: helmClients,
+		hrClient:           hrClient,
+		hrLister:           hrLister,
+		helmClients:        helmClients,
+		defaultHelmVersion: defaultHelmVersion,
 	}
 }
 
@@ -66,7 +67,7 @@ bail:
 		for _, hr := range list {
 			nsHrClient := u.hrClient.HelmV1().HelmReleases(hr.Namespace)
 			releaseName := hr.GetReleaseName()
-			c, ok := u.helmClients.Load(hr.GetHelmVersion())
+			c, ok := u.helmClients.Load(hr.GetHelmVersion(u.defaultHelmVersion))
 			// If we are unable to get the client, we do not care why
 			if !ok {
 				continue


### PR DESCRIPTION
This commit adds proper support for enabling Helm client versions
and configuring the default Helm client version.

The enabled versions can be set by either setting the
`--enabled-helm-versions` flag, or the `HELM_VERSION` environment
variable.

The first version given will become the default client for
`HelmRelease` resources that do not have a `helmVersion` declared in
their spec.