### PR TITLE
Chart: fix backwards compatibility git default ref

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -6,7 +6,7 @@ a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) p
 ## Prerequisites
 
 * Kubernetes >= v1.11
-* Tiller >= v2.14
+* Tiller >= v2.16
 
 ## Installation
 

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -70,8 +70,9 @@ git:
   # Period on which to poll git chart sources for changes
   pollInterval: "5m"
   timeout: "20s"
-  # Ref to clone chart from if ref is unspecified in a HelmRelease
-  defaultRef: "master"
+  # Ref to clone chart from if ref is unspecified in a HelmRelease,
+  # empty defaults to `master`
+  defaultRef: ""
   # Overrides for git over SSH. If you use your own git server, you
   # will likely need to provide a host key for it in this field.
   ssh:


### PR DESCRIPTION
The flag is set based on the existence of the `git.defaultRef` value,
as the default of not setting the flag also equals to `master`, leaving
it empty in `values.yaml` makes the chart maintain backwards
compatability with Helm operator versions prior to the version that
added the flag while still offering the same functionalities.