### PR TITLE
helm/v2: mimic v3 `--atomic` behaviour in client

### DIFF
--- a/pkg/helm/v2/helm.go
+++ b/pkg/helm/v2/helm.go
@@ -1,15 +1,17 @@
 package v2
 
 import (
+	"errors"
 	"fmt"
 	"time"
+
+	"github.com/go-kit/kit/log"
+	"google.golang.org/grpc/status"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	helmv2 "k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/tlsutil"
-
-	"github.com/go-kit/kit/log"
 
 	"github.com/fluxcd/helm-operator/pkg/helm"
 )
@@ -118,4 +120,11 @@ func tillerHost(kubeClient *kubernetes.Clientset, opts TillerOptions) (string, e
 	}
 
 	return fmt.Sprintf("%s:%s", opts.Host, opts.Port), nil
+}
+
+func statusMessageErr(err error) error {
+	if s, ok := status.FromError(err); ok {
+		return errors.New(s.Message())
+	}
+	return err
 }

--- a/pkg/helm/v2/history.go
+++ b/pkg/helm/v2/history.go
@@ -12,7 +12,7 @@ import (
 func (h *HelmV2) History(releaseName string, opts helm.HistoryOptions) ([]*helm.Release, error) {
 	res, err := h.client.ReleaseHistory(releaseName, helmv2.WithMaxHistory(int32(opts.Max)))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve history for [%s]", releaseName)
+		return nil, errors.Wrapf(statusMessageErr(err), "failed to retrieve history for [%s]", releaseName)
 	}
 	return getReleaseHistory(res.Releases), nil
 }

--- a/pkg/helm/v2/rollback.go
+++ b/pkg/helm/v2/rollback.go
@@ -1,9 +1,6 @@
 package v2
 
 import (
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/status"
-
 	helmv2 "k8s.io/helm/pkg/helm"
 
 	"github.com/fluxcd/helm-operator/pkg/helm"
@@ -21,10 +18,7 @@ func (h *HelmV2) Rollback(releaseName string, opts helm.RollbackOptions) (*helm.
 		helmv2.RollbackForce(opts.Force),
 	)
 	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return nil, errors.New(s.Message())
-		}
-		return nil, err
+		return nil, statusMessageErr(err)
 	}
 	return releaseToGenericRelease(res.Release), nil
 }

--- a/pkg/helm/v2/status.go
+++ b/pkg/helm/v2/status.go
@@ -3,9 +3,6 @@ package v2
 import (
 	"strings"
 
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/status"
-
 	helmv2 "k8s.io/helm/pkg/helm"
 
 	"github.com/fluxcd/helm-operator/pkg/helm"
@@ -16,11 +13,9 @@ func (h *HelmV2) Status(releaseName string, opts helm.StatusOptions) (*helm.Rele
 	// the full release, which is required to construct a `helm.Release`.
 	res, err := h.client.ReleaseContent(releaseName, helmv2.ContentReleaseVersion(int32(opts.Version)))
 	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			if strings.Contains(s.Message(), "not found") {
-				return nil, nil
-			}
-			return nil, errors.New(s.Message())
+		err = statusMessageErr(err)
+		if strings.Contains(err.Error(), "not found") {
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/pkg/helm/v2/uninstall.go
+++ b/pkg/helm/v2/uninstall.go
@@ -1,9 +1,6 @@
 package v2
 
 import (
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/status"
-
 	helmv2 "k8s.io/helm/pkg/helm"
 
 	"github.com/fluxcd/helm-operator/pkg/helm"
@@ -17,10 +14,7 @@ func (h *HelmV2) Uninstall(releaseName string, opts helm.UninstallOptions) error
 		helmv2.DeletePurge(!opts.KeepHistory),
 		helmv2.DeleteTimeout(int64(opts.Timeout.Seconds())),
 	); err != nil {
-		if s, ok := status.FromError(err); ok {
-			return errors.New(s.Message())
-		}
-		return err
+		return statusMessageErr(err)
 	}
 	return nil
 }

--- a/pkg/helm/v2/upgrade.go
+++ b/pkg/helm/v2/upgrade.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"github.com/pkg/errors"
-	"google.golang.org/grpc/status"
 
 	"k8s.io/helm/pkg/chartutil"
 	helmv2 "k8s.io/helm/pkg/helm"
@@ -37,9 +36,17 @@ func (h *HelmV2) UpgradeFromPath(chartPath string, releaseName string, values []
 			helmv2.ValueOverrides(values),
 			helmv2.InstallDisableHooks(opts.DisableHooks),
 			helmv2.InstallDryRun(opts.DryRun),
-			helmv2.InstallWait(opts.Wait),
+			helmv2.InstallWait(opts.Wait || opts.Atomic),
 			helmv2.InstallTimeout(int64(opts.Timeout.Seconds())),
 		)
+		if err != nil && opts.Atomic {
+			h.logger.Log("warning", "installation failed with atomic flag set, uninstalling release")
+			_, dErr := h.client.DeleteRelease(releaseName,
+				helmv2.DeletePurge(true), helmv2.DeleteDisableHooks(opts.DisableHooks))
+			if dErr != nil {
+				return nil, errors.Wrapf(statusMessageErr(dErr), "failed to uninstall release, original installation error: %s", statusMessageErr(err))
+			}
+		}
 	} else {
 		res, err = h.client.UpdateReleaseFromChart(
 			releaseName,
@@ -52,14 +59,22 @@ func (h *HelmV2) UpgradeFromPath(chartPath string, releaseName string, values []
 			helmv2.ReuseValues(opts.ReuseValues),
 			helmv2.ResetValues(opts.ResetValues),
 			helmv2.UpgradeTimeout(int64(opts.Timeout.Seconds())),
-			helmv2.UpgradeWait(opts.Wait),
+			helmv2.UpgradeWait(opts.Wait || opts.Atomic),
 		)
+		if err != nil && opts.Atomic {
+			h.logger.Log("warning", "upgrade failed with atomic flag set, rolling back release")
+			_, rErr := h.client.RollbackRelease(releaseName,
+				helmv2.RollbackTimeout(int64(opts.Timeout.Seconds())),
+				helmv2.RollbackWait(opts.Wait),
+				helmv2.RollbackDisableHooks(opts.DisableHooks),
+				helmv2.RollbackDryRun(opts.DryRun),
+				helmv2.RollbackRecreate(opts.Recreate),
+				helmv2.RollbackForce(opts.Force))
+			return nil, errors.Wrapf(statusMessageErr(rErr), "failed to roll back release, original installation error: %s", statusMessageErr(err))
+		}
 	}
 	if err != nil {
-		if s, ok := status.FromError(err); ok {
-			return nil, errors.New(s.Message())
-		}
-		return nil, err
+		return nil, statusMessageErr(err)
 	}
 	return releaseToGenericRelease(res.GetRelease()), nil
 }

--- a/pkg/helm/v3/release.go
+++ b/pkg/helm/v3/release.go
@@ -72,7 +72,7 @@ func formatVersion(c *chart.Chart) string {
 }
 
 // lookUpGenericStatus looks up the generic status for the
-// given v3 status
+// given v3 release status.
 func lookUpGenericStatus(s release.Status) helm.Status {
 	var statuses = map[release.Status]helm.Status{
 		release.StatusUnknown:         helm.StatusUnknown,

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -213,10 +213,6 @@ func (r *Release) Sync(client helm.Client, hr *v1.HelmRelease) (rHr *v1.HelmRele
 		// If this is the first release, or rollbacks are not enabled;
 		// return and wait for the next signal to retry...
 		if curRel == nil || !hr.Spec.Rollback.Enable {
-			// TODO(hidde): for Helm v2, mimic the v3 `--atomic` behaviour which automatically
-			// deletes the release on installation failure.
-			client.Uninstall(hr.GetReleaseName(), helm.UninstallOptions{Namespace: hr.GetTargetNamespace()})
-
 			return hr, err
 		}
 


### PR DESCRIPTION
This commit mimics the Helm v3 `--atomic` behaviour in the `v2` client layer, so that we can rely on this behaviour in the `release` package and do not have to take care of the removal of a release ourselves when something fails.