### PR TITLE
Added extraVolumes and extraVolumeMounts for Helm Operator

### DIFF
--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
       - name: {{ .Values.configureRepositories.cacheVolumeName | quote }}
         emptyDir: {}
       {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
       containers:
       - name: flux-helm-operator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -138,6 +141,9 @@ spec:
           readOnly: true
         - name: {{ .Values.configureRepositories.cacheVolumeName | quote }}
           mountPath: /var/fluxd/helm/repository/cache
+        {{- end }}
+        {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
         {{- end }}
         args:
         {{- if .Values.logFormat }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -162,6 +162,8 @@ nodeSelector: {}
 annotations: {}
 tolerations: []
 affinity: {}
+extraVolumeMounts: []
+extraVolumes: []
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
Hi,

It's possible to mount volumes on the Flux daemon but not on Helm Operator.
In my context, I proxify the GIT protocol, and I need to mount a configuration file.