### PR TITLE
helm/v3: supply getters to downloader manager

### DIFF
--- a/pkg/helm/v3/dependency.go
+++ b/pkg/helm/v3/dependency.go
@@ -18,6 +18,7 @@ func (h *HelmV3) DependencyUpdate(chartPath string) error {
 		ChartPath:        chartPath,
 		RepositoryConfig: repositoryConfig,
 		RepositoryCache:  repositoryCache,
+		Getters:          getters,
 	}
 	return man.Update()
 }


### PR DESCRIPTION
The getters were added in #124 but not supplied to the `downloader.Manager` hence the reported error in https://github.com/fluxcd/helm-operator/issues/68#issuecomment-559527194.