### PR TITLE
Support import of repositories for Helm v2 _and_ v3

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -124,7 +124,7 @@ func init() {
 }
 
 func main() {
-	// Explicitly initialize klog to enable stderr logging,
+	// explicitly initialize klog to enable stderr logging,
 	// and parse our own flags.
 	klog.InitFlags(nil)
 	fs.Parse(os.Args)
@@ -134,7 +134,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Support enabling the Helm supported versions through an
+	// support enabling the Helm supported versions through an
 	// environment variable.
 	helmVersionEnv := getEnvAsSlice("HELM_VERSION", []string{})
 	if len(helmVersionEnv) > 0 && !fs.Changed("enabled-helm-versions") {
@@ -171,6 +171,7 @@ func main() {
 
 	mainLogger := log.With(logger, "component", "helm-operator")
 
+	// build Kubernetes clients
 	cfg, err := clientcmd.BuildConfigFromFlags(*master, *kubeconfig)
 	if err != nil {
 		mainLogger.Log("error", fmt.Sprintf("error building kubeconfig: %v", err))
@@ -189,11 +190,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// initialize versioned Helm clients
 	helmClients := &helm.Clients{}
 	for _, v := range *enabledHelmVersions {
+		versionedLogger := log.With(logger, "component", "helm", "version", v)
+
 		switch v {
 		case v2.VERSION:
-			helmClients.Add(v2.VERSION, v2.New(log.With(logger, "component", "helm", "version", "v2"), kubeClient, v2.TillerOptions{
+			helmClients.Add(v2.VERSION, v2.New(versionedLogger, kubeClient, v2.TillerOptions{
 				Host:        *tillerIP,
 				Port:        *tillerPort,
 				Namespace:   *tillerNamespace,
@@ -205,11 +209,7 @@ func main() {
 				TLSHostname: *tillerTLSHostname,
 			}))
 		case v3.VERSION:
-			client := v3.New(log.With(logger, "component", "helm", "version", "v3"), cfg)
-			// TODO(hidde): remove hardcoded path
-			if err := client.(*v3.HelmV3).RepositoryImport("/var/fluxd/helm/repository/repositories.yaml"); err != nil {
-				mainLogger.Log("warning", "failed to import Helm chart repositories from path", "err", err)
-			}
+			client := v3.New(versionedLogger, cfg)
 			helmClients.Add(v3.VERSION, client)
 		default:
 			mainLogger.Log("error", fmt.Sprintf("%s is not a supported Helm version, ignoring...", v))

--- a/docs/references/operator.md
+++ b/docs/references/operator.md
@@ -26,6 +26,9 @@ take action accordingly.
 | `--kubeconfig`              |                               | Path to a kubeconfig. Only required if out-of-cluster.
 | `--master`                  |                               | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
 | `--allow-namespace`         |                               | If set, this limits the scope to a single namespace. if not specified, all namespaces will be watched.
+| **Helm options**
+| `--enabled-helm-versions`   | `v2,v3`                       | The Helm client versions supported by this operator instance
+| `--helm-repository-import`  |                               | Targeted version and the path of the Helm repository index to import, i.e. `v3:/tmp/v3/index.yaml,v2:/tmp/v2/index.yaml`
 | **Tiller options**
 | `--tiller-ip`               |                               | Tiller IP address. Only required if out-of-cluster.
 | `--tiller-port`             |                               | Tiller port.

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -30,6 +30,10 @@ type Client interface {
 	History(releaseName string, opts HistoryOptions) ([]*Release, error)
 	Rollback(releaseName string, opts RollbackOptions) (*Release, error)
 	DependencyUpdate(chartPath string) error
+	RepositoryIndex() error
+	RepositoryAdd(name, url, username, password, certFile, keyFile, caFile string) error
+	RepositoryRemove(name string) error
+	RepositoryImport(path string) error
 	Uninstall(releaseName string, opts UninstallOptions) error
 	Version() string
 }

--- a/pkg/helm/v2/repository.go
+++ b/pkg/helm/v2/repository.go
@@ -1,0 +1,142 @@
+package v2
+
+import (
+	"os"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/helm/pkg/getter"
+	"k8s.io/helm/pkg/repo"
+)
+
+var (
+	repositoryConfigLock sync.RWMutex
+	getters              = getter.Providers{{
+		Schemes: []string{"http", "https"},
+		New:     func(URL, CertFile, KeyFile, CAFile string) (getter.Getter, error) {
+			return getter.NewHTTPGetter(URL, CertFile, KeyFile, CAFile)
+		},
+	}}
+)
+
+func (h *HelmV2) RepositoryIndex() error {
+	repositoryConfigLock.RLock()
+	defer repositoryConfigLock.RUnlock()
+
+	f, err := loadRepositoryConfig()
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	for _, c := range f.Repositories {
+		r, err := repo.NewChartRepository(c, getters)
+		if err != nil {
+			return err
+		}
+		wg.Add(1)
+		go func(r *repo.ChartRepository) {
+			if err := r.DownloadIndexFile(repositoryCache); err != nil {
+				h.logger.Log("error", "unable to get an update from the chart repository", "url", r.Config.URL, "err", err)
+			} else {
+				h.logger.Log("info", "successfully got an update from the chart repository", "url", r.Config.URL)
+			}
+			wg.Done()
+		}(r)
+	}
+	wg.Wait()
+	return nil
+}
+
+func (h *HelmV2) RepositoryAdd(name, url, username, password, certFile, keyFile, caFile string) error {
+	repositoryConfigLock.Lock()
+	defer repositoryConfigLock.Unlock()
+
+	f, err := loadRepositoryConfig()
+	if err != nil {
+		return err
+	}
+
+	c := &repo.Entry{
+		Name:     name,
+		URL:      url,
+		Username: username,
+		Password: password,
+		CertFile: certFile,
+		KeyFile:  keyFile,
+		CAFile:   caFile,
+	}
+	f.Add(c)
+
+	if f.Has(name) {
+		return errors.New("chart repository with name %s already exists")
+	}
+
+	r, err := repo.NewChartRepository(c, getters)
+	if err != nil {
+		return err
+	}
+	if err = r.DownloadIndexFile(repositoryCache); err != nil {
+		return err
+	}
+
+	return f.WriteFile(repositoryConfig, 0644)
+}
+
+func (h *HelmV2) RepositoryRemove(name string) error {
+	repositoryConfigLock.Lock()
+	defer repositoryConfigLock.Unlock()
+
+	f, err := repo.LoadRepositoriesFile(repositoryConfig)
+	if err != nil {
+		return err
+	}
+	f.Remove(name)
+
+	return f.WriteFile(repositoryConfig, 0644)
+}
+
+func (h *HelmV2) RepositoryImport(path string) error {
+	s, err := repo.LoadRepositoriesFile(path)
+	if err != nil {
+		return err
+	}
+
+	repositoryConfigLock.Lock()
+	defer repositoryConfigLock.Unlock()
+
+	t, err := loadRepositoryConfig()
+	if err != nil {
+		return err
+	}
+
+	for _, c := range s.Repositories {
+		if t.Has(c.Name) {
+			h.logger.Log("error", "repository with name already exists", "name", c.Name, "url", c.URL)
+			continue
+		}
+		r, err := repo.NewChartRepository(c, getters)
+		if err != nil {
+			h.logger.Log("error", err, "name", c.Name, "url", c.URL)
+			continue
+		}
+		if err := r.DownloadIndexFile(repositoryCache); err != nil {
+			h.logger.Log("error", err, "name", c.Name, "url", c.URL)
+			continue
+		}
+
+		t.Add(c)
+		h.logger.Log("info", "successfully imported repository", "name", c.Name, "url", c.URL)
+	}
+
+	return t.WriteFile(repositoryConfig, 0644)
+}
+
+func loadRepositoryConfig() (*repo.RepoFile, error) {
+	r, err := repo.LoadRepositoriesFile(repositoryConfig)
+	if err != nil && !os.IsNotExist(errors.Cause(err)) {
+		return nil, err
+	}
+	return r, nil
+}


### PR DESCRIPTION
This PR adds the missing bits in the `helm/v2` package, removes the hardcoded import that was temporary put into place in #124, and replaces it with a dedicated `--helm-repository-import` flag which accepts a string slice of `[helm version]:[path]` pairs.