### PR TITLE
helm: include chart files, templates and deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/fluxcd/flux v1.15.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-kit/kit v0.9.0
+	github.com/golang/protobuf v1.3.2
 	github.com/google/go-cmp v0.3.1
 	github.com/gorilla/handlers v1.4.2 // indirect
 	github.com/gorilla/mux v1.7.1
 	github.com/gosuri/uitable v0.0.3 // indirect
 	github.com/instrumenta/kubeval v0.0.0-20190804145309-805845b47dfc
+	github.com/ncabatoff/go-seq v0.0.0-20180805175032-b08ef85ed833
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,7 @@ github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/ncabatoff/go-seq v0.0.0-20180805175032-b08ef85ed833 h1:t4WWQ9I797y7QUgeEjeXnVb+oYuEDQc6gLvrZJTYo94=
 github.com/ncabatoff/go-seq v0.0.0-20180805175032-b08ef85ed833/go.mod h1:0CznHmXSjMEqs5Tezj/w2emQoM41wzYM9KpDKUHPYag=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -24,20 +24,6 @@ const (
 	StatusPendingRollback Status = "pending-rollback"
 )
 
-// Chart describes the chart for a release
-type Chart struct {
-	Name       string
-	Version    string
-	AppVersion string
-}
-
-// Info holds metadata of a chart deployment
-type Info struct {
-	LastDeployed time.Time
-	Description  string
-	Status       Status
-}
-
 // Release describes a generic chart deployment
 type Release struct {
 	Name      string
@@ -47,6 +33,31 @@ type Release struct {
 	Values    map[string]interface{}
 	Manifest  string
 	Version   int
+}
+
+// Info holds metadata of a chart deployment
+type Info struct {
+	LastDeployed time.Time
+	Description  string
+	Status       Status
+}
+
+// Chart describes the chart for a release
+type Chart struct {
+	Name         string
+	Version      string
+	AppVersion   string
+	Files        []*File
+	Templates    []*File
+	Dependencies []*Chart
+}
+
+// File represents a file as a name/value pair.
+// The name is a relative path within the scope
+// of the chart's base directory.
+type File struct {
+	Name string
+	Data []byte
 }
 
 // Status holds the status of a release

--- a/pkg/helm/v2/dependency.go
+++ b/pkg/helm/v2/dependency.go
@@ -12,10 +12,10 @@ func (h *HelmV2) DependencyUpdate(chartPath string) error {
 
 	out := helm.NewLogWriter(h.logger)
 	man := downloader.Manager{
-		Out: out,
+		Out:       out,
 		ChartPath: chartPath,
-		HelmHome: helmHome(),
-		Getters: getters,
+		HelmHome:  helmHome(),
+		Getters:   getters,
 	}
 	return man.Update()
 }

--- a/pkg/helm/v2/helm.go
+++ b/pkg/helm/v2/helm.go
@@ -22,8 +22,8 @@ import (
 const VERSION = "v2"
 
 var (
-	repositoryConfig   = helmHome().RepositoryFile()
-	repositoryCache    = helmHome().Cache()
+	repositoryConfig = helmHome().RepositoryFile()
+	repositoryCache  = helmHome().Cache()
 )
 
 // TillerOptions holds configuration options for tiller

--- a/pkg/helm/v2/repository.go
+++ b/pkg/helm/v2/repository.go
@@ -14,7 +14,7 @@ var (
 	repositoryConfigLock sync.RWMutex
 	getters              = getter.Providers{{
 		Schemes: []string{"http", "https"},
-		New:     func(URL, CertFile, KeyFile, CAFile string) (getter.Getter, error) {
+		New: func(URL, CertFile, KeyFile, CAFile string) (getter.Getter, error) {
 			return getter.NewHTTPGetter(URL, CertFile, KeyFile, CAFile)
 		},
 	}}

--- a/pkg/helm/v3/helm.go
+++ b/pkg/helm/v3/helm.go
@@ -117,7 +117,7 @@ func initActionConfig(kubeConfig *rest.Config, opts HelmOptions) (*action.Config
 func writeTempKubeConfig(kc *rest.Config) (string, string, func(), error) {
 	tmpDir, err := ioutil.TempDir("", "helmv3")
 	if err != nil {
-		return "", "", func(){}, err
+		return "", "", func() {}, err
 	}
 	cleanup := func() { os.RemoveAll(tmpDir) }
 

--- a/pkg/helm/v3/release.go
+++ b/pkg/helm/v3/release.go
@@ -33,7 +33,7 @@ func chartToGenericChart(c *chart.Chart) *helm.Chart {
 		Name:         c.Name(),
 		Version:      formatVersion(c),
 		AppVersion:   c.AppVersion(),
-		Files:		  filesToGenericFiles(c.Files),
+		Files:        filesToGenericFiles(c.Files),
 		Templates:    filesToGenericFiles(c.Templates),
 		Dependencies: dependenciesToGenericDependencies(c.Dependencies()),
 	}

--- a/pkg/helm/v3/release.go
+++ b/pkg/helm/v3/release.go
@@ -1,6 +1,10 @@
 package v3
 
 import (
+	"sort"
+
+	"github.com/ncabatoff/go-seq/seq"
+
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
@@ -26,10 +30,39 @@ func releaseToGenericRelease(r *release.Release) *helm.Release {
 // a generic `helm.Chart`
 func chartToGenericChart(c *chart.Chart) *helm.Chart {
 	return &helm.Chart{
-		Name:       c.Name(),
-		Version:    formatVersion(c),
-		AppVersion: c.AppVersion(),
+		Name:         c.Name(),
+		Version:      formatVersion(c),
+		AppVersion:   c.AppVersion(),
+		Files:		  filesToGenericFiles(c.Files),
+		Templates:    filesToGenericFiles(c.Templates),
+		Dependencies: dependenciesToGenericDependencies(c.Dependencies()),
 	}
+}
+
+// filesToGenericFiles transforms a `chart.File` slice into
+// an stable sorted slice with generic `helm.File`s
+func filesToGenericFiles(f []*chart.File) []*helm.File {
+	gf := make([]*helm.File, len(f))
+	for i, ff := range f {
+		gf[i] = &helm.File{Name: ff.Name, Data: ff.Data}
+	}
+	sort.SliceStable(gf, func(i, j int) bool {
+		return seq.Compare(gf[i], gf[j]) > 0
+	})
+	return gf
+}
+
+// dependenciesToGenericDependencies transforms a `chart.Chart` dependency
+// slice into a stable sorted slice with generic `helm.Chart` dependencies.
+func dependenciesToGenericDependencies(d []*chart.Chart) []*helm.Chart {
+	gd := make([]*helm.Chart, len(d))
+	for i, dd := range d {
+		gd[i] = chartToGenericChart(dd)
+	}
+	sort.SliceStable(gd, func(i, j int) bool {
+		return seq.Compare(gd[i], gd[j]) > 0
+	})
+	return gd
 }
 
 // infoToGenericInfo transforms a v3 info structure into

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/fluxcd/flux/pkg/git"
 	"github.com/go-kit/kit/log"
 	"github.com/google/go-cmp/cmp"
 
@@ -95,7 +96,10 @@ func (r *Release) Sync(client helm.Client, hr *v1.HelmRelease) (rHr *v1.HelmRele
 	var chartPath, revision string
 	switch {
 	case hr.Spec.GitChartSource != nil:
-		export, revision, err := r.gitChartSync.GetMirrorCopy(hr)
+		var export *git.Export
+		var err error
+
+		export, revision, err = r.gitChartSync.GetMirrorCopy(hr)
 		if err != nil {
 			switch err.(type) {
 			case chartsync.ChartUnavailableError:

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -30,10 +30,10 @@ import (
 )
 
 type Updater struct {
-	hrClient    ifclientset.Interface
-	hrLister    iflister.HelmReleaseLister
-	kube        kube.Interface
-	helmClients *helm.Clients
+	hrClient           ifclientset.Interface
+	hrLister           iflister.HelmReleaseLister
+	kube               kube.Interface
+	helmClients        *helm.Clients
 	defaultHelmVersion string
 }
 

--- a/test/e2e/15_upgrade.bats
+++ b/test/e2e/15_upgrade.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+function setup() {
+  # Load libraries in setup() to access BATS_* variables
+  load lib/env
+  load lib/defer
+  load lib/install
+  load lib/poll
+
+  kubectl create namespace "$E2E_NAMESPACE"
+
+  # Install the git server, allowing external access
+  install_git_srv git_srv_result
+  # shellcheck disable=SC2154
+  export GIT_SSH_COMMAND="${git_srv_result[0]}"
+  # Teardown the created port-forward to gitsrv.
+  defer kill "${git_srv_result[1]}"
+
+  install_tiller
+  install_helm_operator_with_helm
+
+  kubectl create namespace "$DEMO_NAMESPACE"
+}
+
+@test "Git mituation causes upgrade" {
+  # Apply the HelmRelease fixtures
+  kubectl apply -f "$FIXTURES_DIR/releases/git.yaml" >&3
+
+  # Wait for it to be deployed
+  poll_until_equals 'podinfo-git HelmRelease' 'deployed' "kubectl -n $DEMO_NAMESPACE get helmrelease/podinfo-git -o 'custom-columns=status:status.releaseStatus' --no-headers"
+
+  # Clone the charts repository
+  local clone_dir
+  clone_dir="$(mktemp -d)"
+  defer rm -rf "'$clone_dir'"
+  git clone -b master ssh://git@localhost/git-server/repos/cluster.git "$clone_dir"
+  cd "$clone_dir"
+
+  # Make a chart template mutation in Git without bumping the version number
+  sed -i 's%these commands:%these commands;%' charts/podinfo/templates/NOTES.txt
+  git add charts/podinfo/templates/NOTES.txt
+  git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -m "Modify NOTES.txt"
+
+  # Record new HEAD and push change
+  head_hash=$(git rev-list -n 1 HEAD)
+  git push >&3
+
+  # Assert change is rolled out
+  poll_until_equals 'podinfo-git HelmRelease chart update' "successfully cloned chart revision: $head_hash" "kubectl -n $DEMO_NAMESPACE get helmrelease/podinfo-git -o jsonpath='{.status.conditions[?(@.type==\"ChartFetched\")].message}'"
+  poll_until_equals 'podinfo-git HelmRelease revision matches' "$head_hash" "kubectl -n $DEMO_NAMESPACE get helmrelease/podinfo-git -o jsonpath='{.status.revision}'"
+}
+
+function teardown() {
+  run_deffered
+
+  # Removing the operator also takes care of the global resources it installs.
+  uninstall_helm_operator_with_helm
+  uninstall_tiller
+  # Removing the namespace also takes care of removing gitsrv.
+  kubectl delete namespace "$E2E_NAMESPACE"
+  # Only remove the demo workloads after the operator, so that they cannot be recreated.
+  kubectl delete namespace "$DEMO_NAMESPACE"
+}


### PR DESCRIPTION
To ensure chart changes without a version bump to e.g. charts from
git sources are detected.

Fixes #149 