### PR TITLE
helm/v3: include credentials when pulling chart

### DIFF
--- a/pkg/helm/v3/pull.go
+++ b/pkg/helm/v3/pull.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"helm.sh/helm/v3/pkg/downloader"
+	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/helm/pkg/urlutil"
 
@@ -9,6 +10,10 @@ import (
 )
 
 func (h *HelmV3) Pull(ref, version, dest string) (string, error) {
+	return h.PullWithOptions(ref, version, dest, []getter.Option{})
+}
+
+func (h *HelmV3) PullWithOptions(ref, version, dest string, options []getter.Option) (string, error) {
 	repositoryConfigLock.RLock()
 	defer repositoryConfigLock.RUnlock()
 
@@ -19,6 +24,7 @@ func (h *HelmV3) Pull(ref, version, dest string) (string, error) {
 		RepositoryConfig: repositoryConfig,
 		RepositoryCache:  repositoryCache,
 		Getters:          getters,
+		Options:          options,
 	}
 	d, _, err := c.DownloadTo(ref, version, dest)
 	return d, err
@@ -61,5 +67,5 @@ func (h *HelmV3) PullWithRepoURL(repoURL, name, version, dest string) (string, e
 		return "", err
 	}
 
-	return h.Pull(chartURL, version, dest)
+	return h.PullWithOptions(chartURL, version, dest, []getter.Option{getter.WithBasicAuth(repoEntry.Username, repoEntry.Password)})
 }

--- a/pkg/helm/v3/pull.go
+++ b/pkg/helm/v3/pull.go
@@ -67,5 +67,8 @@ func (h *HelmV3) PullWithRepoURL(repoURL, name, version, dest string) (string, e
 		return "", err
 	}
 
-	return h.PullWithOptions(chartURL, version, dest, []getter.Option{getter.WithBasicAuth(repoEntry.Username, repoEntry.Password)})
+	return h.PullWithOptions(chartURL, version, dest, []getter.Option{
+		getter.WithBasicAuth(repoEntry.Username, repoEntry.Password),
+		getter.WithTLSClientConfig(repoEntry.CertFile, repoEntry.KeyFile, repoEntry.CAFile),
+	})
 }


### PR DESCRIPTION
Using a private helm repository currently fails, when using helm v3. The issue arises, when attempting to download the chart itself. The credentials are not passed to the downloader.

This pull request rectifies this issue, by passing the credentials on, in the same manner as this [similar code in the helm project](https://github.com/helm/helm/blob/8dddb18de723449282fde2c4266e4ae9263a50e0/pkg/action/pull.go#L59) in the PullWithRepoURL func