### PR TITLE
e2e: fix flakiness of various tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             - go-mod-{{ checksum "go.mod" }}
             - go-mod-
       - run: make check-generated
-      - run: make test TEST_FLAGS="-race -timeout 60s"
+      - run: make test TEST_FLAGS="-race -timeout 5m"
       - run: make all
       - run: make test-docs
       - run:

--- a/test/e2e/15_upgrade.bats
+++ b/test/e2e/15_upgrade.bats
@@ -22,7 +22,7 @@ function setup() {
   kubectl create namespace "$DEMO_NAMESPACE"
 }
 
-@test "Git mituation causes upgrade" {
+@test "Git mutation causes upgrade" {
   # Apply the HelmRelease fixtures
   kubectl apply -f "$FIXTURES_DIR/releases/git.yaml" >&3
 

--- a/test/e2e/15_upgrade.bats
+++ b/test/e2e/15_upgrade.bats
@@ -51,7 +51,7 @@ function setup() {
 }
 
 function teardown() {
-  run_deffered
+  run_deferred
 
   # Removing the operator also takes care of the global resources it installs.
   uninstall_helm_operator_with_helm

--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -41,8 +41,7 @@ function install_helm_operator_with_helm() {
     --set configureRepositories.enable=true \
     --set configureRepositories.repositories[0].name="podinfo" \
     --set configureRepositories.repositories[0].url="https://stefanprodan.github.io/podinfo" \
-    --set extraEnvs[0].name="HELM_VERSION" \
-    --set extraEnvs[0].value="${HELM_VERSION:-v2\,v3}" \
+    --set helm.versions="${HELM_VERSION:-v2\,v3}" \
     "${ROOT_DIR}/chart/helm-operator"
 }
 

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -44,13 +44,13 @@ if ! kubectl version > /dev/null 2>&1; then
 
   echo '>>> Creating Kind Kubernetes cluster(s)'
   KIND_CONFIG_PREFIX="${HOME}/.kube/kind-config-${KIND_CLUSTER_PREFIX}"
-  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m
   for I in $(seq 1 "${E2E_KIND_CLUSTER_NUM}"); do
     defer kind --name "${KIND_CLUSTER_PREFIX}-${I}" delete cluster > /dev/null 2>&1 || true
     defer rm -rf "${KIND_CONFIG_PREFIX}-${I}"
     # Wire tests with the right cluster based on their BATS_JOB_SLOT env variable
     eval export "KUBECONFIG_SLOT_${I}=${KIND_CONFIG_PREFIX}-${I}"
   done
+  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m
 
   echo '>>> Loading images into the Kind cluster(s)'
   seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- kind --name "${KIND_CLUSTER_PREFIX}-{}" load docker-image 'docker.io/fluxcd/helm-operator:latest'

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -37,6 +37,11 @@ E2E_KIND_CLUSTER_NUM=${E2E_KIND_CLUSTER_NUM:-1}
 if ! kubectl version > /dev/null 2>&1; then
   install_kind
 
+  # We require GNU Parallel, but some systems come with Tollef's parallel (moreutils)
+  if ! parallel -h | grep -q "GNU Parallel"; then
+    echo "GNU Parallel is not available on your system"; exit 1
+  fi
+
   echo '>>> Creating Kind Kubernetes cluster(s)'
   KIND_CONFIG_PREFIX="${HOME}/.kube/kind-config-${KIND_CLUSTER_PREFIX}"
   seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m


### PR DESCRIPTION
This improves the stability of the end-to-end tests by fixing the flakiness of various tests. In addition, to help (new) contributors with the setup of the end-to-end tests a check has been added to confirm the `parallel` version on the system is [GNU Parallel and not Tollef's `parallel`, as they behave differently](https://www.gnu.org/software/parallel/parallel_design.html#tollef).