### PR TITLE
e2e: fix authentication issue on `git clone`

### DIFF
--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -78,7 +78,7 @@ function install_git_srv() {
     read -r local_port <&"${COPROC[0]}"-
     # shellcheck disable=SC2001
     local_port=$(echo "$local_port" | sed 's%.*:\([0-9]*\).*%\1%')
-    local ssh_cmd="ssh -o UserKnownHostsFile=/dev/null  -o StrictHostKeyChecking=no -i $gen_dir/id_rsa -p $local_port"
+    local ssh_cmd="ssh -o UserKnownHostsFile=/dev/null  -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i $gen_dir/id_rsa -p $local_port"
     # return the ssh command needed for git, and the PID of the port-forwarding PID into a variable of choice
     eval "${external_access_result_var}=('$ssh_cmd' '$COPROC_PID')"
   fi


### PR DESCRIPTION
In the `15_upgrade` tests when it was doing a git clone it would
report `Too many authentication failures` if there are a number
of different ssh keys on the system. As the tests use a generated
key pair we can tell ssh to only use the supplied identity file and
not try all found keys.

Relates to: #179