### PR TITLE
helm/v2: index repositories before fetching chart

### DIFF
--- a/pkg/helm/v2/pull.go
+++ b/pkg/helm/v2/pull.go
@@ -29,6 +29,13 @@ func (h *HelmV2) PullWithRepoURL(repoURL, name, version, dest string) (string, e
 	// version to a URL, we have to have the index file; and to have
 	// that, we may need to authenticate. The credentials will be in
 	// the repository config.
+
+	// Ensure we have all repo indexes as this is needed by Helm v2 downloader
+	err := h.RepositoryIndex()
+	if err != nil {
+		return "", err
+	}
+
 	repositoryConfigLock.RLock()
 	repoFile, err := loadRepositoryConfig()
 	repositoryConfigLock.RUnlock()
@@ -43,11 +50,6 @@ func (h *HelmV2) PullWithRepoURL(repoURL, name, version, dest string) (string, e
 	for _, entry := range repoFile.Repositories {
 		if urlutil.Equal(repoEntry.URL, entry.URL) {
 			repoEntry = entry
-			// Ensure we have the repository index as this is
-			// later used by Helm.
-			if r, err := repo.NewChartRepository(repoEntry, getters); err == nil {
-				r.DownloadIndexFile(repositoryCache)
-			}
 			break
 		}
 	}

--- a/test/e2e/lib/install.bash
+++ b/test/e2e/lib/install.bash
@@ -39,8 +39,10 @@ function install_helm_operator_with_helm() {
     --set git.ssh.secretName=flux-git-deploy \
     --set-string git.ssh.known_hosts="${KNOWN_HOSTS}" \
     --set configureRepositories.enable=true \
-    --set configureRepositories.repositories[0].name="podinfo" \
-    --set configureRepositories.repositories[0].url="https://stefanprodan.github.io/podinfo" \
+    --set configureRepositories.repositories[0].name="stable" \
+    --set configureRepositories.repositories[0].url="https://kubernetes-charts.storage.googleapis.com" \
+    --set configureRepositories.repositories[1].name="podinfo" \
+    --set configureRepositories.repositories[1].url="https://stefanprodan.github.io/podinfo" \
     --set helm.versions="${HELM_VERSION:-v2\,v3}" \
     "${ROOT_DIR}/chart/helm-operator"
 }


### PR DESCRIPTION
Fix: #164

Helm v2 `ResolveChartVersion` needs to go through each repo cache file to find a matching URL, so we need to download all indexes before attempting to download charts.

Ref: https://github.com/helm/helm/blob/release-2.16/pkg/downloader/chart_downloader.go#L158

