### PR TITLE
release: detect change of charts base values

### DIFF
--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -47,6 +47,7 @@ type Chart struct {
 	Name         string
 	Version      string
 	AppVersion   string
+	Values       Values
 	Files        []*File
 	Templates    []*File
 	Dependencies []*Chart

--- a/pkg/helm/v2/release.go
+++ b/pkg/helm/v2/release.go
@@ -36,10 +36,12 @@ func chartToGenericChart(c *chart.Chart) *helm.Chart {
 	if c == nil || c.Metadata == nil {
 		return nil
 	}
+
 	return &helm.Chart{
 		Name:         c.Metadata.Name,
 		Version:      c.Metadata.Version,
 		AppVersion:   c.Metadata.AppVersion,
+		Values:       valuesToGenericValues(c.Values),
 		Files:        filesToGenericFiles(c.Files),
 		Templates:    templatesToGenericFiles(c.Templates),
 		Dependencies: dependenciesToGenericDependencies(c.Dependencies),

--- a/pkg/helm/v3/release.go
+++ b/pkg/helm/v3/release.go
@@ -33,6 +33,7 @@ func chartToGenericChart(c *chart.Chart) *helm.Chart {
 		Name:         c.Name(),
 		Version:      formatVersion(c),
 		AppVersion:   c.AppVersion(),
+		Values:       c.Values,
 		Files:        filesToGenericFiles(c.Files),
 		Templates:    filesToGenericFiles(c.Templates),
 		Dependencies: dependenciesToGenericDependencies(c.Dependencies()),

--- a/pkg/helm/values.go
+++ b/pkg/helm/values.go
@@ -1,0 +1,29 @@
+package helm
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/ghodss/yaml"
+)
+
+// Values represents a collection of (Helm) values.
+// We define our own type to avoid working with two `chartutil`
+// versions.
+type Values map[string]interface{}
+
+// YAML encodes the values into YAML bytes.
+func (v Values) YAML() ([]byte, error) {
+	b, err := yaml.Marshal(v)
+	return b, err
+}
+
+// Checksum calculates and returns the SHA256 checksum of the YAML
+// encoded values.
+func (v Values) Checksum() string {
+	b, _ := v.YAML()
+
+	hasher := sha256.New()
+	hasher.Write(b)
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -305,7 +305,7 @@ func (r *Release) Uninstall(client helm.Client, hr *v1.HelmRelease) {
 // before running the dry-run release to determine if any undefined
 // mutations have occurred.
 func shouldSync(logger log.Logger, client helm.Client, hr *v1.HelmRelease, curRel *helm.Release,
-	chartPath string, values values, logDiffs bool) (bool, error) {
+	chartPath string, values helm.Values, logDiffs bool) (bool, error) {
 
 	if curRel == nil {
 		logger.Log("info", "no existing release", "action", "install")


### PR DESCRIPTION
Fix #174 

From my investigation I found that upon running the dry-run we compare to see if the release values have changed but never actually checked to see if the charts base values themselves actually changed.

This adds a checksum of the chart values to the Chart type which in turn leads to the chart comparison to see a difference resulting in a release to occur when the base charts values are changed.

I also did some slight refactoring to move the existing Checksum logic into the helm package and changed any existing stuff to use that.

@hiddeco let me know what other changes you envisage here, one thing we could do and I am unsure about is return the actual values on the Chart and not just a checksum, but given we are not using them for anything else the checksum might be the simplest route.