### PR TITLE
release: filter out nil release resources during parsing

### DIFF
--- a/pkg/release/annotator.go
+++ b/pkg/release/annotator.go
@@ -95,6 +95,10 @@ func releaseManifestToUnstructured(manifest string, logger log.Logger) []unstruc
 			continue
 		}
 
+		if len(bytes) == 0 {
+			continue
+		}
+
 		var u unstructured.Unstructured
 		if err := u.UnmarshalJSON(bytes); err != nil {
 			logger.Log("err", err)


### PR DESCRIPTION
This was once fixed in #47, but returned as a regression bug due
to a merge mistake.

Fix for https://github.com/fluxcd/helm-operator/issues/8#issuecomment-569433618