### PR TITLE
release: ignore manifest in annotator if we fail to unmarshal

### DIFF
--- a/pkg/release/annotator.go
+++ b/pkg/release/annotator.go
@@ -14,7 +14,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
+	v1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
 	"github.com/fluxcd/helm-operator/pkg/helm"
 )
 
@@ -89,19 +89,9 @@ func releaseManifestToUnstructured(manifest string, logger log.Logger) []unstruc
 	manifests := releaseutil.SplitManifests(manifest)
 	var objs []unstructured.Unstructured
 	for _, manifest := range manifests {
-		bytes, err := yaml.YAMLToJSON([]byte(manifest))
-		if err != nil {
-			logger.Log("err", err)
-			continue
-		}
-
-		if len(bytes) == 0 {
-			continue
-		}
-
 		var u unstructured.Unstructured
-		if err := u.UnmarshalJSON(bytes); err != nil {
-			logger.Log("err", err)
+
+		if err := yaml.Unmarshal([]byte(manifest), &u); err != nil {
 			continue
 		}
 


### PR DESCRIPTION
#185 covered the case where the len(bytes)==0 however in my testing I witnessed that the reason I still get this error is because I am seeing manifests come through that are simply the string "null".