### PR TITLE
Add extra log line before we perform the dry-run upgrade

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -336,6 +336,8 @@ func shouldSync(logger log.Logger, client helm.Client, hr *v1.HelmRelease, curRe
 	}
 
 	if !status.HasSynced(*hr) {
+		logger.Log("info", "release has not yet been processed", "action", "upgrade")
+
 		// The generation of this `v1.HelmRelease` has not been
 		// processed, we should simply sync.
 		return true, nil
@@ -346,6 +348,8 @@ func shouldSync(logger log.Logger, client helm.Client, hr *v1.HelmRelease, curRe
 		// Without valid YAML values we are unable to sync.
 		return false, ErrComposingValues
 	}
+
+	logger.Log("info", "performing dry-run upgrade to see if release has diverged")
 
 	// Perform a dry-run upgrade so that we can compare what we ought
 	// to be running matches what is defined in the `v1.HelmRelease`.


### PR DESCRIPTION
Closes #202 

Adding an extra log line before we go perform the dry-run upgrade, one more thing I thought about this is that we can control the log format of our own logs however the helm logs themselves we can not so once you set the --log-format=json we now get a mix of log types in our output which is slightly anoying.