### PR TITLE
release: record rolled back chart revision

### DIFF
--- a/pkg/apis/helm.fluxcd.io/v1/types.go
+++ b/pkg/apis/helm.fluxcd.io/v1/types.go
@@ -18,7 +18,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// FluxHelmRelease represents custom resource associated with a Helm Chart
+// HelmRelease represents custom resource associated with a Helm Chart
 type HelmRelease struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -241,6 +241,11 @@ type HelmReleaseStatus struct {
 	// +optional
 	Revision string `json:"revision,omitempty"`
 
+	// PrevRevision would define what Git hash or Chart version had previously
+	// been deployed.
+	// +optional
+	PrevRevision string `json:"prevRevision,omitempty"`
+
 	// Conditions contains observations of the resource's state, e.g.,
 	// has the chart which it refers to been fetched.
 	// +optional
@@ -302,7 +307,7 @@ func (in *HelmValues) DeepCopyInto(out *HelmValues) {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// HelmReleaseList is a list of FluxHelmRelease resources
+// HelmReleaseList is a list of HelmRelease resources
 type HelmReleaseList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"fmt"
-	"github.com/fluxcd/helm-operator/pkg/release"
 	"sync"
 	"time"
 
@@ -24,7 +23,7 @@ import (
 	hrv1 "github.com/fluxcd/helm-operator/pkg/client/informers/externalversions/helm.fluxcd.io/v1"
 	iflister "github.com/fluxcd/helm-operator/pkg/client/listers/helm.fluxcd.io/v1"
 	"github.com/fluxcd/helm-operator/pkg/helm"
-	"github.com/fluxcd/helm-operator/pkg/status"
+	"github.com/fluxcd/helm-operator/pkg/release"
 )
 
 const (
@@ -101,8 +100,7 @@ func New(
 	// ----- EVENT HANDLERS for HelmRelease resources change ---------
 	hrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(new interface{}) {
-			hr, ok := checkCustomResourceType(controller.logger, new)
-			if ok && !status.HasRolledBack(hr) {
+			if _, ok := checkCustomResourceType(controller.logger, new); ok {
 				controller.enqueueJob(new)
 			}
 		},


### PR DESCRIPTION
By comparing this recorded revision we are able to detect if we have
already performed an upgrade for a given revision in case the chart
cache has been cleared.