### PR TITLE
Reject git source if URL and path are missing

### DIFF
--- a/pkg/chartsync/git.go
+++ b/pkg/chartsync/git.go
@@ -68,6 +68,12 @@ func (c sourceRef) forHelmRelease(hr *v1.HelmRelease) bool {
 	if hr == nil || hr.Spec.GitChartSource == nil {
 		return false
 	}
+
+	// reject git source if URL and path are missing
+	if hr.Spec.GitURL == "" || hr.Spec.Path == "" {
+		return false
+	}
+
 	return c.mirror == mirrorName(hr) && c.remote == hr.Spec.GitURL && c.ref == hr.Spec.Ref
 }
 
@@ -75,15 +81,12 @@ func NewGitChartSync(logger log.Logger,
 	lister lister.HelmReleaseLister, cfg GitConfig, queue ReleaseQueue) *GitChartSync {
 
 	return &GitChartSync{
-		logger: logger,
-		config: cfg,
-
-		lister: lister,
-
+		logger:             logger,
+		config:             cfg,
+		lister:             lister,
 		mirrors:            git.NewMirrors(),
 		releaseSourcesByID: make(map[string]sourceRef),
-
-		releaseQueue: queue,
+		releaseQueue:       queue,
 	}
 }
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -95,7 +95,7 @@ func (r *Release) Sync(client helm.Client, hr *v1.HelmRelease) (rHr *v1.HelmRele
 	// to the chart, and record the revision.
 	var chartPath, revision string
 	switch {
-	case hr.Spec.GitChartSource != nil:
+	case hr.Spec.GitChartSource != nil && hr.Spec.GitURL != "" && hr.Spec.Path != "":
 		var export *git.Export
 		var err error
 


### PR DESCRIPTION
Helm operator choses to use a Git source when a chart comes from a Helm repository if `ref` is specified. This PR fixes the Git source detection by validating the git URL and path.

HR release spec that is mistaken for a Git source:
```yaml
spec:
  chart:
    name: expressjs-k8s
    ref: master
    repository: https://alexellis.github.io/expressjs-k8s/
    version: 0.1.1
```

