### PR TITLE
chart: Allow pod annotations, labels and account annotations to be set

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -195,9 +195,12 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `tolerations`                                     | `[]`                                                 | Tolerations properties for the deployment
 | `affinity`                                        | `{}`                                                 | Affinity properties for the deployment
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Helm Operator pod(s)
+| `podAnnotations`                                  | `{}`                                                 | Additional pod annotations
+| `podLabels`                                       | `{}`                                                 | Additional pod labels
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
 | `rbac.pspEnabled`                                 | `false`                                              | If `true`, create and use a restricted pod security policy for Helm Operator pod(s)
 | `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
+| `serviceAccount.annotations`                      | ``                                                   | Additional Service Account annotations
 | `serviceAccount.name`                             | `flux`                                               | Service account to be used
 | `clusterRole.create`                              | `true`                                               | If `false`, Helm Operator will be restricted to the namespace where is deployed
 | `createCRD`                                       | `false`                                              | Create the HelmRelease CRD

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ template "helm-operator.name" . }}
@@ -20,12 +20,19 @@ spec:
       {{- if .Values.prometheus.enabled }}
         prometheus.io/scrape: "true"
       {{- end }}
-      {{- if .Values.annotations }}
-      {{- .Values.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+      {{- if .Values.podAnnotations }}
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       {{- end }}
       labels:
         app: {{ template "helm-operator.name" . }}
         release: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+      {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "helm-operator.serviceAccountName" . }}
       {{- if .Values.image.pullSecret }}

--- a/chart/helm-operator/templates/serviceaccount.yaml
+++ b/chart/helm-operator/templates/serviceaccount.yaml
@@ -8,4 +8,10 @@ metadata:
     chart: {{ template "helm-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -129,6 +129,8 @@ rbac:
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Service account annotations
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
@@ -175,9 +177,9 @@ extraEnvs: []
 #   - name: FOO
 #     value: bar
 
-replicaCount: 1
+podAnnotations: {}
+podLabels: {}
 nodeSelector: {}
-annotations: {}
 tolerations: []
 affinity: {}
 extraVolumeMounts: []


### PR DESCRIPTION
Allow custom configuration for:
- pod annotations
- pod labels
- service account annotations

Set replica to 1 as multiple replicas are not supported.