### PR TITLE
helm/v3: propogate main application logger to client

### DIFF
--- a/pkg/helm/v3/get.go
+++ b/pkg/helm/v3/get.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *HelmV3) Get(releaseName string, opts helm.GetOptions) (*helm.Release, error) {
-	cfg, cleanup, err := initActionConfig(h.kc, HelmOptions{Namespace: opts.Namespace})
+	cfg, cleanup, err := h.initActionConfig(HelmOptions{Namespace: opts.Namespace})
 	defer cleanup()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup Helm client")

--- a/pkg/helm/v3/history.go
+++ b/pkg/helm/v3/history.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (h *HelmV3) History(releaseName string, opts helm.HistoryOptions) ([]*helm.Release, error) {
-	cfg, cleanup, err := initActionConfig(h.kc, HelmOptions{Namespace: opts.Namespace})
+	cfg, cleanup, err := h.initActionConfig(HelmOptions{Namespace: opts.Namespace})
 	defer cleanup()
 
 	if err != nil {

--- a/pkg/helm/v3/rollback.go
+++ b/pkg/helm/v3/rollback.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *HelmV3) Rollback(releaseName string, opts helm.RollbackOptions) (*helm.Release, error) {
-	cfg, cleanup, err := initActionConfig(h.kc, HelmOptions{Namespace: opts.Namespace})
+	cfg, cleanup, err := h.initActionConfig(HelmOptions{Namespace: opts.Namespace})
 	defer cleanup()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup Helm client")

--- a/pkg/helm/v3/uninstall.go
+++ b/pkg/helm/v3/uninstall.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *HelmV3) Uninstall(releaseName string, opts helm.UninstallOptions) error {
-	cfg, cleanup, err := initActionConfig(h.kc, HelmOptions{Namespace: opts.Namespace})
+	cfg, cleanup, err := h.initActionConfig(HelmOptions{Namespace: opts.Namespace})
 	defer cleanup()
 	if err != nil {
 		return errors.Wrap(err, "failed to setup Helm client")

--- a/pkg/helm/v3/upgrade.go
+++ b/pkg/helm/v3/upgrade.go
@@ -14,7 +14,7 @@ import (
 func (h *HelmV3) UpgradeFromPath(chartPath string, releaseName string, values []byte,
 	opts helm.UpgradeOptions) (*helm.Release, error) {
 
-	cfg, cleanup, err := initActionConfig(h.kc, HelmOptions{Namespace: opts.Namespace})
+	cfg, cleanup, err := h.initActionConfig(HelmOptions{Namespace: opts.Namespace})
 	defer cleanup()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to setup Helm client")


### PR DESCRIPTION
The Helm V3 code was passing in klog.Infof for the logger which meant that we were missing out on formatting the internal helm logs using our configured logger and the users logging preferences.

This change creates a logging function to mimic klog.Infof and simply routes it to our logger as an info level log.

Example of logs being consistent across both our components and the internal helm logs.

```
ts=2020-01-21T18:43:25.501926825Z caller=operator.go:307 component=operator info="enqueuing release" resource=opa:helmrelease/jupyterhub
ts=2020-01-21T18:43:25.603914422Z caller=release.go:353 component=release release=podinfo-child targetNamespace=opa resource=opa:helmrelease/jupyterhub helmVersion=v3 info="performing dry-run upgrade to see if release has diverged"
ts=2020-01-21T18:43:25.606268155Z caller=helm.go:167 component=helm version=v3 info="preparing upgrade for podinfo-child"
ts=2020-01-21T18:43:26.00569832Z caller=helm.go:167 component=helm version=v3 info="performing update for podinfo-child"
ts=2020-01-21T18:43:26.010283371Z caller=helm.go:167 component=helm version=v3 info="dry run for podinfo-child"
```

Closes #226 