### PR TITLE
release: rely on Helm storage for rollbacks

### DIFF
--- a/pkg/apis/helm.fluxcd.io/v1/types.go
+++ b/pkg/apis/helm.fluxcd.io/v1/types.go
@@ -260,19 +260,10 @@ type HelmReleaseStatus struct {
 	// the controller.
 	ObservedGeneration int64 `json:"observedGeneration"`
 
-	// ValuesChecksum holds the SHA256 checksum of the last applied
-	// values.
-	ValuesChecksum string `json:"valuesChecksum"`
-
 	// Revision would define what Git hash or Chart version has currently
 	// been deployed.
 	// +optional
 	Revision string `json:"revision,omitempty"`
-
-	// PrevRevision would define what Git hash or Chart version had previously
-	// been deployed.
-	// +optional
-	PrevRevision string `json:"prevRevision,omitempty"`
 
 	// Conditions contains observations of the resource's state, e.g.,
 	// has the chart which it refers to been fetched.

--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -44,11 +44,11 @@ type Info struct {
 
 // Chart describes the chart for a release
 type Chart struct {
-	Name         string
-	Version      string
-	AppVersion   string
-	Values       Values
-	Templates    []*File
+	Name       string
+	Version    string
+	AppVersion string
+	Values     Values
+	Templates  []*File
 }
 
 // File represents a file as a name/value pair.

--- a/pkg/helm/v2/history.go
+++ b/pkg/helm/v2/history.go
@@ -4,24 +4,22 @@ import (
 	"github.com/pkg/errors"
 
 	helmv2 "k8s.io/helm/pkg/helm"
-	"k8s.io/helm/pkg/proto/hapi/release"
 
 	"github.com/fluxcd/helm-operator/pkg/helm"
 )
 
 func (h *HelmV2) History(releaseName string, opts helm.HistoryOptions) ([]*helm.Release, error) {
-	res, err := h.client.ReleaseHistory(releaseName, helmv2.WithMaxHistory(int32(opts.Max)))
+	max := helmv2.WithMaxHistory(256)
+	if opts.Max != 0 {
+		max = helmv2.WithMaxHistory(int32(opts.Max))
+	}
+	res, err := h.client.ReleaseHistory(releaseName, max)
 	if err != nil {
 		return nil, errors.Wrapf(statusMessageErr(err), "failed to retrieve history for [%s]", releaseName)
 	}
-	return getReleaseHistory(res.Releases), nil
-}
-
-func getReleaseHistory(rls []*release.Release) []*helm.Release {
-	history := make([]*helm.Release, len(rls))
-	for i := len(rls) - 1; i >= 0; i-- {
-		r := rls[i]
-		history = append(history, releaseToGenericRelease(r))
+	var rels []*helm.Release
+	for _, r := range res.Releases {
+		rels = append(rels, releaseToGenericRelease(r))
 	}
-	return history
+	return rels, nil
 }

--- a/pkg/helm/v2/release.go
+++ b/pkg/helm/v2/release.go
@@ -38,11 +38,11 @@ func chartToGenericChart(c *chart.Chart) *helm.Chart {
 	}
 
 	return &helm.Chart{
-		Name:         c.Metadata.Name,
-		Version:      c.Metadata.Version,
-		AppVersion:   c.Metadata.AppVersion,
-		Values:       valuesToGenericValues(c.Values),
-		Templates:    templatesToGenericFiles(c.Templates),
+		Name:       c.Metadata.Name,
+		Version:    c.Metadata.Version,
+		AppVersion: c.Metadata.AppVersion,
+		Values:     valuesToGenericValues(c.Values),
+		Templates:  templatesToGenericFiles(c.Templates),
 	}
 }
 

--- a/pkg/helm/v3/history.go
+++ b/pkg/helm/v3/history.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pkg/errors"
 
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/releaseutil"
 
 	"github.com/fluxcd/helm-operator/pkg/helm"
@@ -28,21 +27,11 @@ func (h *HelmV3) History(releaseName string, opts helm.HistoryOptions) ([]*helm.
 
 	releaseutil.Reverse(hist, releaseutil.SortByRevision)
 
-	var rels []*release.Release
+	var rels []*helm.Release
 	for i := 0; i < min(len(hist), client.Max); i++ {
-		rels = append(rels, hist[i])
+		rels = append(rels, releaseToGenericRelease(hist[i]))
 	}
-
-	return getReleaseHistory(hist), nil
-}
-
-func getReleaseHistory(rls []*release.Release) []*helm.Release {
-	history := make([]*helm.Release, len(rls))
-	for i := len(rls) - 1; i >= 0; i-- {
-		r := rls[i]
-		history = append(history, releaseToGenericRelease(r))
-	}
-	return history
+	return rels, nil
 }
 
 func min(x, y int) int {

--- a/pkg/helm/v3/release.go
+++ b/pkg/helm/v3/release.go
@@ -30,11 +30,11 @@ func releaseToGenericRelease(r *release.Release) *helm.Release {
 // a generic `helm.Chart`
 func chartToGenericChart(c *chart.Chart) *helm.Chart {
 	return &helm.Chart{
-		Name:         c.Name(),
-		Version:      formatVersion(c),
-		AppVersion:   c.AppVersion(),
-		Values:       c.Values,
-		Templates:    filesToGenericFiles(c.Templates),
+		Name:       c.Name(),
+		Version:    formatVersion(c),
+		AppVersion: c.AppVersion(),
+		Values:     c.Values,
+		Templates:  filesToGenericFiles(c.Templates),
 	}
 }
 


### PR DESCRIPTION
This commit removes our own state keeping around rollbacks except
for the condition we set marking a rollback has happened, but
instead relies on comparison of a dry-run with the latest failed
release. If this results in a diff, a new upgrade will be attempted.

The reason we move to this approach is that it is not possible to
take all variables safely into account and determine if we should
perform a new upgrade attempt based on our own bookkeeping, with
a long list of edge-case bugs as a result.

Relying on the real truth is always better than a reflection of it,
which in the end may not be the actual truth at all.

Fixes #236