### PR TITLE
helm: do not include non-template files in chart data

### DIFF
--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -48,7 +48,6 @@ type Chart struct {
 	Version      string
 	AppVersion   string
 	Values       Values
-	Files        []*File
 	Templates    []*File
 }
 

--- a/pkg/helm/v2/release.go
+++ b/pkg/helm/v2/release.go
@@ -42,7 +42,6 @@ func chartToGenericChart(c *chart.Chart) *helm.Chart {
 		Version:      c.Metadata.Version,
 		AppVersion:   c.Metadata.AppVersion,
 		Values:       valuesToGenericValues(c.Values),
-		Files:        filesToGenericFiles(c.Files),
 		Templates:    templatesToGenericFiles(c.Templates),
 	}
 }

--- a/pkg/helm/v3/release.go
+++ b/pkg/helm/v3/release.go
@@ -34,7 +34,6 @@ func chartToGenericChart(c *chart.Chart) *helm.Chart {
 		Version:      formatVersion(c),
 		AppVersion:   c.AppVersion(),
 		Values:       c.Values,
-		Files:        filesToGenericFiles(c.Files),
 		Templates:    filesToGenericFiles(c.Templates),
 	}
 }


### PR DESCRIPTION
As the non-template files include the `requirements.lock` file,
which in case of a chart with dependencies differs every time
a dry-run happens due to the generation timestamp it includes,
resulting in spurious upgrades.

Other files included there are non-trivial for the detection of
changes as their effects are either captured in other parts of
the chart metadata, or do not matter at all for the release
itself, like the contents of a `README.md`.


Fixes #218 