### PR TITLE
Release Helm chart 0.6.0

### DIFF
--- a/chart/helm-operator/CHANGELOG.md
+++ b/chart/helm-operator/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.6.0 (2020-01-26)
+
+### Improvements
+
+ - Update Helm Operator to `1.0.0-rc8`
+   [fluxcd/helm-operator#244](https://github.com/fluxcd/helm-operator/pull/244)
+ - Allow pod annotations, labels and account annotations to be set
+   [fluxcd/helm-operator#229](https://github.com/fluxcd/helm-operator/pull/229)
+
 ## 0.5.0 (2020-01-10)
 
 ### Improvements

--- a/chart/helm-operator/Chart.yaml
+++ b/chart/helm-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0.0-rc8"
-version: 0.5.0
+version: 0.6.0
 kubeVersion: ">=1.11.0-0"
 name: helm-operator
 description: Flux Helm Operator is a CRD controller for declarative helming


### PR DESCRIPTION
 - Update Helm Operator to `1.0.0-rc8`
   [fluxcd/helm-operator#244](https://github.com/fluxcd/helm-operator/pull/244)
 - Allow pod annotations, labels and account annotations to be set
   [fluxcd/helm-operator#229](https://github.com/fluxcd/helm-operator/pull/229)
