### PR TITLE
release: propagate flags to dry-run upgrade

### DIFF
--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -340,7 +340,12 @@ func shouldSync(logger log.Logger, client helm.Client, hr *v1.HelmRelease, curRe
 	// latest release _or_ the latest failed release in case of a rollback.
 	// If this results in one or more diffs we should sync.
 	logger.Log("info", "performing dry-run upgrade to see if release has diverged")
-	desRel, err := client.UpgradeFromPath(chartPath, hr.GetReleaseName(), b, helm.UpgradeOptions{DryRun: true})
+	desRel, err := client.UpgradeFromPath(chartPath, hr.GetReleaseName(), b, helm.UpgradeOptions{
+		DryRun: true,
+		Namespace: hr.GetTargetNamespace(),
+		Force: hr.Spec.ForceUpgrade,
+		ResetValues: hr.Spec.ResetValues,
+	})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
So that the dry-run equals to what is run during the actual upgrade.

Addresses part of #249.