### PR TITLE
build: adding generate-codegen step to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,11 @@ cache/bats-core-$(BATS_COMMIT).tar.gz:
 	# Use 2opremio's fork until https://github.com/bats-core/bats-core/pull/255 is merged
 	curl --fail -L -o $@ https://github.com/2opremio/bats-core/archive/$(BATS_COMMIT).tar.gz
 
+generate: generate-codegen generate-deploy
+
+generate-codegen:
+	./hack/update/generated.sh
+
 generate-deploy: pkg/install/generated_templates.gogen.go
 	cd deploy && go run ../pkg/install/generate.go deploy
 	cp ./deploy/flux-helm-release-crd.yaml ./chart/helm-operator/crds/helmrelease.yaml


### PR DESCRIPTION
After having had to play the generate dance a few times now, feels like adding a `make generate-go` step that will do the Go generation will make life easier and with the addition of a `make generate` step to do all the generating at once.

This will also simplify things as I write up the Getting started developing docs (coming soon).