### PR TITLE
build: do not create kind clusters in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,16 @@
-version: 2
+version: 2.1
+commands:
+  e2e_tests:
+    parameters:
+      helm_version:
+        type: string
+    steps:
+      - run:
+          name: End-to-end Helm <<parameters.helm_version>>
+          command: make e2e
+          environment:
+            E2E_KIND_CLUSTER_NUM: 2
+            HELM_VERSION: <<parameters.helm_version>>
 jobs:
   build:
     working_directory: /home/circleci/go/src/github.com/fluxcd/helm-operator
@@ -55,16 +67,10 @@ jobs:
       - run: make test TEST_FLAGS="-race -timeout 5m"
       - run: make all
       - run: make test-docs
-      - run:
-          name: End-to-end Helm v2
-          command: E2E_KIND_CLUSTER_NUM=4 make e2e
-          environment:
-            HELM_VERSION: v2
-      - run:
-          name: End-to-end Helm v3
-          command: E2E_KIND_CLUSTER_NUM=4 make e2e
-          environment:
-            HELM_VERSION: v3
+      - e2e_tests:
+          helm_version: v2
+      - e2e_tests:
+          helm_version: v3
       - save_cache:
           key: cache-{{ checksum "Makefile" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
           name: End-to-end Helm <<parameters.helm_version>>
           command: make e2e
           environment:
-            E2E_KIND_CLUSTER_NUM: 2
+            E2E_KIND_CLUSTER_NUM: 4
             HELM_VERSION: <<parameters.helm_version>>
 jobs:
   build:

--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -51,7 +51,9 @@ if ! kubectl version > /dev/null 2>&1; then
     # Wire tests with the right cluster based on their BATS_JOB_SLOT env variable
     eval export "KUBECONFIG_SLOT_${I}=${KIND_CONFIG_PREFIX}-${I}"
   done
-  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m --image kindest/node:${KUBE_VERSION}
+  # Due to https://github.com/kubernetes-sigs/kind/issues/1288
+  # limit parallel creation of clusters to 1 job.
+  seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -j 1 -- env KUBECONFIG="${KIND_CONFIG_PREFIX}-{}" kind create cluster --name "${KIND_CLUSTER_PREFIX}-{}" --wait 5m --image kindest/node:${KUBE_VERSION}
 
   echo '>>> Loading images into the Kind cluster(s)'
   seq 1 "${E2E_KIND_CLUSTER_NUM}" | time parallel -- kind --name "${KIND_CLUSTER_PREFIX}-{}" load docker-image 'docker.io/fluxcd/helm-operator:latest'


### PR DESCRIPTION
Noticing the test flakes and saw the discussion in https://github.com/kubernetes-sigs/kind/issues/1288 changing to 2 parallel jobs to see if that has any effect on stability of the e2e suite in CI, @hiddeco any objection to trying this out?

I also factored the e2e tests out into a CircleCI command which IMO cleans things up a little but required an update to the 2.1 build (which should not break anything else).