### PR TITLE
helm/v3: add release name to log context for internal Helm logs

### DIFF
--- a/pkg/helm/v3/get.go
+++ b/pkg/helm/v3/get.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *HelmV3) Get(releaseName string, opts helm.GetOptions) (*helm.Release, error) {
-	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc, opts.Namespace, "")
+	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc(opts.Namespace, releaseName), opts.Namespace, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helm/v3/helm.go
+++ b/pkg/helm/v3/helm.go
@@ -26,9 +26,9 @@ import (
 const VERSION = "v3"
 
 var (
-	repositoryConfig   = helmpath.ConfigPath("repositories.yaml")
-	repositoryCache    = helmpath.CachePath("repository")
-	pluginsDir         = helmpath.DataPath("plugins")
+	repositoryConfig = helmpath.ConfigPath("repositories.yaml")
+	repositoryCache  = helmpath.CachePath("repository")
+	pluginsDir       = helmpath.DataPath("plugins")
 )
 
 type HelmOptions struct {
@@ -63,9 +63,11 @@ func (h *HelmV3) Version() string {
 
 // infoLogFunc allows us to pass our logger to components
 // that expect a klog.Infof function.
-func (h *HelmV3) infoLogFunc(format string, args ...interface{}) {
-	message := fmt.Sprintf(format, args...)
-	h.logger.Log("info", message)
+func (h *HelmV3) infoLogFunc(namespace string, releaseName string) infoLogFunc {
+	return func(format string, args ...interface{}) {
+		message := fmt.Sprintf(format, args...)
+		h.logger.Log("info", message, "targetNamespace", namespace, "release", releaseName)
+	}
 }
 
 func newActionConfig(config *rest.Config, logFunc infoLogFunc, namespace, driver string) (*action.Configuration, error) {

--- a/pkg/helm/v3/history.go
+++ b/pkg/helm/v3/history.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *HelmV3) History(releaseName string, opts helm.HistoryOptions) ([]*helm.Release, error) {
-	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc, opts.Namespace, "")
+	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc(opts.Namespace, releaseName), opts.Namespace, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helm/v3/rollback.go
+++ b/pkg/helm/v3/rollback.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *HelmV3) Rollback(releaseName string, opts helm.RollbackOptions) (*helm.Release, error) {
-	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc, opts.Namespace, "")
+	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc(opts.Namespace, releaseName), opts.Namespace, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/helm/v3/uninstall.go
+++ b/pkg/helm/v3/uninstall.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (h *HelmV3) Uninstall(releaseName string, opts helm.UninstallOptions) error {
-	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc, opts.Namespace, "")
+	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc(opts.Namespace, releaseName), opts.Namespace, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/v3/upgrade.go
+++ b/pkg/helm/v3/upgrade.go
@@ -14,7 +14,7 @@ import (
 func (h *HelmV3) UpgradeFromPath(chartPath string, releaseName string, values []byte,
 	opts helm.UpgradeOptions) (*helm.Release, error) {
 
-	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc, opts.Namespace, "")
+	cfg, err := newActionConfig(h.kubeConfig, h.infoLogFunc(opts.Namespace, releaseName), opts.Namespace, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add release to log context for the logger func that is used to log internal helm logs.

Closes #240 