### PR TITLE
Update for Helm 3 on OSX using Library

### DIFF
--- a/docs/references/helmrelease-custom-resource.md
+++ b/docs/references/helmrelease-custom-resource.md
@@ -413,7 +413,9 @@ the filename.
 cp ~/.helm/repository/repositories.yaml .
 sed -i -e 's/^\( *cache: \).*\/\(.*\.yaml\)/\1\2/g' repositories.yaml
 ```
-If you are using OSX and Helm 3 the command will be
+
+If you are using OSX and Helm 3 the command will be:
+
 ```sh
 cp ~/Library/Preferences/helm/repositories.yaml
 ```

--- a/docs/references/helmrelease-custom-resource.md
+++ b/docs/references/helmrelease-custom-resource.md
@@ -413,6 +413,10 @@ the filename.
 cp ~/.helm/repository/repositories.yaml .
 sed -i -e 's/^\( *cache: \).*\/\(.*\.yaml\)/\1\2/g' repositories.yaml
 ```
+If you are using OSX and Helm 3 the command will be
+```sh
+cp ~/Library/Preferences/helm/repositories.yaml
+```
 
 Now you can create a secret in the same namespace as you're running
 the Helm operator, from the repositories file:


### PR DESCRIPTION
note the sed can be removed with Helm 3 generally since cache is no longer included

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
