### PR TITLE
release: configure go logger to log using our go-kit logger

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	golog "log"
 	"os"
 	"os/signal"
 	"strings"
@@ -23,12 +24,13 @@ import (
 	clientset "github.com/fluxcd/helm-operator/pkg/client/clientset/versioned"
 	ifinformers "github.com/fluxcd/helm-operator/pkg/client/informers/externalversions"
 	"github.com/fluxcd/helm-operator/pkg/helm"
-	"github.com/fluxcd/helm-operator/pkg/helm/v2"
-	"github.com/fluxcd/helm-operator/pkg/helm/v3"
+	helmv2 "github.com/fluxcd/helm-operator/pkg/helm/v2"
+	helmv3 "github.com/fluxcd/helm-operator/pkg/helm/v3"
 	daemonhttp "github.com/fluxcd/helm-operator/pkg/http/daemon"
 	"github.com/fluxcd/helm-operator/pkg/operator"
 	"github.com/fluxcd/helm-operator/pkg/release"
 	"github.com/fluxcd/helm-operator/pkg/status"
+	"github.com/fluxcd/helm-operator/pkg/utils"
 )
 
 var (
@@ -124,7 +126,7 @@ func init() {
 
 	versionedHelmRepositoryIndexes = fs.StringSlice("helm-repository-import", nil, "Targeted version and the path of the Helm repository index to import, i.e. v3:/tmp/v3/index.yaml,v2:/tmp/v2/index.yaml")
 
-	enabledHelmVersions = fs.StringSlice("enabled-helm-versions", []string{v2.VERSION, v3.VERSION}, "Helm versions supported by this operator instance")
+	enabledHelmVersions = fs.StringSlice("enabled-helm-versions", []string{helmv2.VERSION, helmv3.VERSION}, "Helm versions supported by this operator instance")
 }
 
 func main() {
@@ -158,6 +160,10 @@ func main() {
 		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 		logger = log.With(logger, "caller", log.DefaultCaller)
 	}
+
+	// configure go logger to output using go-kit log
+	logWriter := utils.NewLogWriter(logger)
+	golog.SetOutput(logWriter)
 
 	// error channel
 	errc := make(chan error)
@@ -200,8 +206,8 @@ func main() {
 		versionedLogger := log.With(logger, "component", "helm", "version", v)
 
 		switch v {
-		case v2.VERSION:
-			helmClients.Add(v2.VERSION, v2.New(versionedLogger, kubeClient, v2.TillerOptions{
+		case helmv2.VERSION:
+			helmClients.Add(helmv2.VERSION, helmv2.New(versionedLogger, kubeClient, helmv2.TillerOptions{
 				Host:        *tillerIP,
 				Port:        *tillerPort,
 				Namespace:   *tillerNamespace,
@@ -212,9 +218,9 @@ func main() {
 				TLSCACert:   *tillerTLSCACert,
 				TLSHostname: *tillerTLSHostname,
 			}))
-		case v3.VERSION:
-			client := v3.New(versionedLogger, cfg)
-			helmClients.Add(v3.VERSION, client)
+		case helmv3.VERSION:
+			client := helmv3.New(versionedLogger, cfg)
+			helmClients.Add(helmv3.VERSION, client)
 		default:
 			mainLogger.Log("error", fmt.Sprintf("unsupported Helm version: %s", v))
 			continue

--- a/pkg/helm/v2/dependency.go
+++ b/pkg/helm/v2/dependency.go
@@ -3,11 +3,11 @@ package v2
 import (
 	"k8s.io/helm/pkg/downloader"
 
-	"github.com/fluxcd/helm-operator/pkg/helm"
+	"github.com/fluxcd/helm-operator/pkg/utils"
 )
 
 func (h *HelmV2) DependencyUpdate(chartPath string) error {
-	out := helm.NewLogWriter(h.logger)
+	out := utils.NewLogWriter(h.logger)
 	man := downloader.Manager{
 		Out:       out,
 		ChartPath: chartPath,

--- a/pkg/helm/v2/pull.go
+++ b/pkg/helm/v2/pull.go
@@ -9,14 +9,14 @@ import (
 	"k8s.io/helm/pkg/repo"
 	"k8s.io/helm/pkg/urlutil"
 
-	"github.com/fluxcd/helm-operator/pkg/helm"
+	"github.com/fluxcd/helm-operator/pkg/utils"
 )
 
 func (h *HelmV2) Pull(ref, version, dest string) (string, error) {
 	repositoryConfigLock.RLock()
 	defer repositoryConfigLock.RUnlock()
 
-	out := helm.NewLogWriter(h.logger)
+	out := utils.NewLogWriter(h.logger)
 	c := downloader.ChartDownloader{
 		Out:      out,
 		HelmHome: helmHome(),

--- a/pkg/helm/v3/dependency.go
+++ b/pkg/helm/v3/dependency.go
@@ -3,11 +3,11 @@ package v3
 import (
 	"helm.sh/helm/v3/pkg/downloader"
 
-	"github.com/fluxcd/helm-operator/pkg/helm"
+	"github.com/fluxcd/helm-operator/pkg/utils"
 )
 
 func (h *HelmV3) DependencyUpdate(chartPath string) error {
-	out := helm.NewLogWriter(h.logger)
+	out := utils.NewLogWriter(h.logger)
 	man := &downloader.Manager{
 		Out:              out,
 		ChartPath:        chartPath,

--- a/pkg/helm/v3/pull.go
+++ b/pkg/helm/v3/pull.go
@@ -11,14 +11,14 @@ import (
 	"helm.sh/helm/v3/pkg/helmpath"
 	"helm.sh/helm/v3/pkg/repo"
 
-	"github.com/fluxcd/helm-operator/pkg/helm"
+	"github.com/fluxcd/helm-operator/pkg/utils"
 )
 
 func (h *HelmV3) Pull(ref, version, dest string) (string, error) {
 	repositoryConfigLock.RLock()
 	defer repositoryConfigLock.RUnlock()
 
-	out := helm.NewLogWriter(h.logger)
+	out := utils.NewLogWriter(h.logger)
 	c := downloader.ChartDownloader{
 		Out:              out,
 		Verify:           downloader.VerifyNever,

--- a/pkg/utils/logwriter.go
+++ b/pkg/utils/logwriter.go
@@ -1,4 +1,4 @@
-package helm
+package utils
 
 import (
 	"fmt"


### PR DESCRIPTION
Ensure all logging is wrapped using our logger so that the things like the users preferred logging format is respected for all logs even those logging directly to `log.Printf`.

This somewhat tackles #301 but due to the reasons mentioned over there adding log context to these log lines is not possibly without introducing changes over in Helm itself.

Tested this using an unknown hook as seen to be logging using `log.Printf` here https://github.com/helm/helm/blob/840bbc951ea026297a5afeffdf913bd6bc79f20f/pkg/releaseutil/manifest_sorter.go#L192

```
ts=2020-02-16T18:52:09.869319509Z caller=logwriter.go:28 info="2020/02/16 18:52:09 info: skipping unknown hook: \"foo\""
```