### PR TITLE
allow envFrom secretName

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -236,6 +236,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `tolerations`                                     | `[]`                                                 | Tolerations properties for the deployment
 | `affinity`                                        | `{}`                                                 | Affinity properties for the deployment
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Helm Operator pod(s)
+| `env.secretName`                                  | ``                                                   |	Name of the secret that contains environment variables which should be defined in the container (using envFrom)
 | `podAnnotations`                                  | `{}`                                                 | Additional pod annotations
 | `podLabels`                                       | `{}`                                                 | Additional pod labels
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -249,6 +249,11 @@ spec:
         env:
 {{ toYaml .Values.extraEnvs | indent 8 }}
       {{- end }}
+    {{- if .Values.env.secretName }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.env.secretName }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.tillerSidecar.enabled }}
@@ -292,4 +297,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
-

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -180,6 +180,12 @@ prometheus:
     namespace:
     additionalLabels: {}
 
+# The contents of the secret will be defined as environment variables
+# in the Flux container. Once defined, you can use the variables ala
+# `git.url`: `https://$(GIT_AUTHUSER):$(GIT_AUTHKEY)@github.com/fluxcd/flux-get-started.git`
+env:
+  secretName: ""
+
 # Additional environment variables to set
 extraEnvs: []
 # extraEnvs:


### PR DESCRIPTION
flux can easily be configured for [git over HTTPS](https://github.com/fluxcd/flux/tree/master/chart/flux#flux-with-git-over-https). 

This PR allows the same secret (or any secret) to be easily used for both the `flux` and `helm-operator` releases