### PR TITLE
Added hostAliases to deployment template

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -289,3 +289,4 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `prometheus.serviceMonitor.namespace`             | ``                                                   | The namespace where the ServiceMonitor is deployed
 | `prometheus.serviceMonitor.additionalLabels`      | `{}`                                                 | Additional labels to add to the ServiceMonitor
 | `initContainers`                                  | `[]`                                                 | Init containers and their specs
+| `hostAliases`                                     | `{}`                                                 | Host aliases allow the modification of the hosts file (/etc/hosts) inside Helm Operator container. See <https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/>

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -280,6 +280,10 @@ spec:
         - name: TILLER_HISTORY_MAX
           value: "10"
       {{- end }}
+{{- if .Values.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.hostAliases |indent 8 }}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -198,3 +198,14 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+# Host aliases allow the modification of the hosts file (/etc/hosts) inside Helm Operator container.
+hostAliases: {}
+# - ip: "127.0.0.1"
+#   hostnames:
+#   - "foo.local"
+#   - "bar.local"
+# - ip: "10.1.2.3"
+#   hostnames:
+#   - "foo.remote"
+#   - "bar.remote"
+


### PR DESCRIPTION
This PR affects Flux Helm Operator chart. It aims to add the ability to statically resolve FQDNs of a Helm charts repository or a git server. By adding a new `hostAliases` parameter to `values.yaml` file, a user can enrich `/etc/hosts` file inside helm operator container by passing his entries to the Helm chart. 
I don't see where this change can be documented. Please let me know if needed.
Thanks
