### PR TITLE
Tune chart defaults for production use

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -64,7 +64,8 @@ chart and their default values.
 | `image.pullSecret`                                | `None`                                               | Image pull secret
 | `resources.requests.cpu`                          | `50m`                                                | CPU resource requests for the deployment
 | `resources.requests.memory`                       | `64Mi`                                               | Memory resource requests for the deployment
-| `resources.limits`                                | `None`                                               | CPU/memory resource limits for the deployment
+| `resources.requests.cpu`                          | `None`                                               | CPU resource limits for the deployment
+| `resources.limits.memory`                         | `1Gi`                                                | Memory resource limits for the deployment
 | `nodeSelector`                                    | `{}`                                                 | Node Selector properties for the deployment
 | `tolerations`                                     | `[]`                                                 | Tolerations properties for the deployment
 | `affinity`                                        | `{}`                                                 | Affinity properties for the deployment
@@ -89,7 +90,7 @@ chart and their default values.
 | `git.ssh.configMapName`                           | `None`                                               | The name of a kubernetes config map containing the ssh config
 | `git.ssh.configMapKey`                            | `config`                                             | The name of the key in the kubernetes config map specified above
 | `chartsSyncInterval`                              | `3m`                                                 | Period on which to reconcile the Helm releases with `HelmRelease` resources
-| `statusUpdateInterval`                            | `None`                                               | Period on which to update the Helm release status in `HelmRelease` resources
+| `statusUpdateInterval`                            | `30s`                                                | Period on which to update the Helm release status in `HelmRelease` resources
 | `workers`                                         | `None`                                               | Number of workers processing releases
 | `logFormat`                                       | `fmt`                                                | Log format (fmt or json)
 | `logReleaseDiffs`                                 | `false`                                              | Helm Operator should log the diff when a chart release diverges (possibly insecure)

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -26,9 +26,9 @@ logReleaseDiffs: false
 # Period on which to reconcile the Helm releases with `HelmRelease` resources
 chartsSyncInterval: "3m"
 # Period on which to update the Helm release status in `HelmRelease` resources
-statusUpdateInterval:
+statusUpdateInterval: "30s"
 # Amount of workers processing releases
-workers: 2
+workers: 4
 
 # Helm versions supported by this operator instance
 helm:
@@ -195,6 +195,8 @@ extraVolumeMounts: []
 extraVolumes: []
 initContainers: []
 resources:
+  limits:
+    memory: 1Gi
   requests:
     cpu: 50m
     memory: 64Mi


### PR DESCRIPTION
Changes:
- set controller workers to `4`
- set status update interval to `30s`
- set container memory limit to `1Gi`

The above settings were determined by benchmarking Helm Operator with 100 helm releases. 
The benchmark can be found at https://github.com/stefanprodan/gitops-benchmark