### PR TITLE
chart: revert default memory limit

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -65,7 +65,7 @@ chart and their default values.
 | `resources.requests.cpu`                          | `50m`                                                | CPU resource requests for the deployment
 | `resources.requests.memory`                       | `64Mi`                                               | Memory resource requests for the deployment
 | `resources.requests.cpu`                          | `None`                                               | CPU resource limits for the deployment
-| `resources.limits.memory`                         | `1Gi`                                                | Memory resource limits for the deployment
+| `resources.limits.memory`                         | `None`                                               | Memory resource limits for the deployment
 | `nodeSelector`                                    | `{}`                                                 | Node Selector properties for the deployment
 | `tolerations`                                     | `[]`                                                 | Tolerations properties for the deployment
 | `affinity`                                        | `{}`                                                 | Affinity properties for the deployment

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -195,8 +195,8 @@ extraVolumeMounts: []
 extraVolumes: []
 initContainers: []
 resources:
-  limits:
-    memory: 1Gi
+#  limits:
+#    memory: 1Gi
   requests:
     cpu: 50m
     memory: 64Mi


### PR DESCRIPTION
As the resource usage of the operator depends too much on the charts it processes.