### PR TITLE
Use recreate strategy

### DIFF
--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
     matchLabels:
       app: {{ template "helm-operator.name" . }}
       release: {{ .Release.Name }}
+  strategy:
+    type:  Recreate  
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The RollingUpdate strategy leads to having two helm operator pods running at the same time... this can be a problem if two operators work on the same release. The current high memory consumption of helm operator also leads to other issues...

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
