### PR TITLE
Expose HelmRelease phases as a Prometheus gauge

### DIFF
--- a/pkg/status/conditions.go
+++ b/pkg/status/conditions.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/clock"
 
-	"github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
+	v1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
 	v1client "github.com/fluxcd/helm-operator/pkg/client/clientset/versioned/typed/helm.fluxcd.io/v1"
 )
 
@@ -67,6 +67,7 @@ func SetStatusPhase(client v1client.HelmReleaseInterface, hr *v1.HelmRelease, ph
 	}
 	return SetCondition(client, hr, condition, func(cHr *v1.HelmRelease) {
 		cHr.Status.Phase = phase
+		SetReleasePhaseGauge(phase, hr.Namespace, hr.Name)
 	})
 }
 

--- a/pkg/status/metrics.go
+++ b/pkg/status/metrics.go
@@ -1,0 +1,45 @@
+package status
+
+import (
+	v1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
+	"github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	LabelNamespace   = "namespace"
+	LabelReleaseName = "release_name"
+)
+
+var phaseToGaugeValue = map[v1.HelmReleasePhase]float64{
+	// Unknown is mapped to 0
+	v1.HelmReleasePhaseChartFetchFailed: -4,
+	v1.HelmReleasePhaseFailed:           -3,
+	v1.HelmReleasePhaseRollbackFailed:   -2,
+	v1.HelmReleasePhaseRolledBack:       -1,
+	v1.HelmReleasePhaseRollingBack:      1,
+	v1.HelmReleasePhaseInstalling:       2,
+	v1.HelmReleasePhaseUpgrading:        3,
+	v1.HelmReleasePhaseChartFetched:     4,
+	v1.HelmReleasePhaseSucceeded:        5,
+}
+
+var (
+	releasePhase = prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		Namespace: "flux",
+		Subsystem: "helm_operator",
+		Name:      "release_phase_info",
+		Help:      "Current HelmRelease phase.",
+	}, []string{LabelNamespace, LabelReleaseName})
+)
+
+func SetReleasePhaseGauge(phase v1.HelmReleasePhase, namespace, releaseName string) {
+	value, ok := phaseToGaugeValue[phase]
+	if !ok {
+		value = 0
+	}
+	releasePhase.With(
+		LabelNamespace, namespace,
+		LabelReleaseName, releaseName,
+	).Set(value)
+}


### PR DESCRIPTION
Hello there 👋

I suggest we expose HelmReleases phases as a Prometheus gauge, in the same fashion as [sstarcher/helm-exporter](https://github.com/sstarcher/helm-exporter) for Helm releases status. Phases are mapped to values, with error-related phases mapped to negative values so one can create an alert rule such as `flux_helm_operator_ release_phase_info < 0`.

Addresses #281.
