### PR TITLE
Make probes configurable in the operator deployment manifest

### DIFF
--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -120,14 +120,20 @@ spec:
           httpGet:
             port: 3030
             path: /healthz
-          initialDelaySeconds: 1
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             port: 3030
             path: /healthz
-          initialDelaySeconds: 1
-          timeoutSeconds: 5
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         volumeMounts:
         {{- if .Values.git.ssh.known_hosts }}
         - name: sshknownhosts

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -185,6 +185,20 @@ extraEnvs: []
 #   - name: FOO
 #     value: bar
 
+livenessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
 podAnnotations: {}
 podLabels: {}
 nodeSelector: {}


### PR DESCRIPTION
This change adds support for setting the liveness/readiness probes attributes in the operator deployment manifest.

Fix #396 