### PR TITLE
Fix e2e tests on MacOS.

### DIFF
--- a/test/e2e/15_upgrade.bats
+++ b/test/e2e/15_upgrade.bats
@@ -1,5 +1,13 @@
 #!/usr/bin/env bats
 
+function sed_in_place() {
+  if test "$(uname)" = Darwin ; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 function setup() {
   # Load libraries in setup() to access BATS_* variables
   load lib/env
@@ -37,7 +45,7 @@ function setup() {
   cd "$clone_dir"
 
   # Make a chart template mutation in Git without bumping the version number
-  sed -i '' 's%these commands:%these commands;%' charts/podinfo/templates/NOTES.txt
+  sed_in_place 's%these commands:%these commands;%' charts/podinfo/templates/NOTES.txt
   git add charts/podinfo/templates/NOTES.txt
   git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -m "Modify NOTES.txt"
 
@@ -64,7 +72,7 @@ function setup() {
   cd "$clone_dir"
 
   # Make a values.yaml mutation in Git
-  sed -i '' 's%replicaCount: 1%replicaCount: 2%' charts/podinfo/values.yaml
+  sed_in_place 's%replicaCount: 1%replicaCount: 2%' charts/podinfo/values.yaml
   git add charts/podinfo/values.yaml
   git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -m "Change replicaCount to 2"
 

--- a/test/e2e/15_upgrade.bats
+++ b/test/e2e/15_upgrade.bats
@@ -37,7 +37,7 @@ function setup() {
   cd "$clone_dir"
 
   # Make a chart template mutation in Git without bumping the version number
-  sed -i 's%these commands:%these commands;%' charts/podinfo/templates/NOTES.txt
+  sed -i '' 's%these commands:%these commands;%' charts/podinfo/templates/NOTES.txt
   git add charts/podinfo/templates/NOTES.txt
   git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -m "Modify NOTES.txt"
 
@@ -64,7 +64,7 @@ function setup() {
   cd "$clone_dir"
 
   # Make a values.yaml mutation in Git
-  sed -i 's%replicaCount: 1%replicaCount: 2%' charts/podinfo/values.yaml
+  sed -i '' 's%replicaCount: 1%replicaCount: 2%' charts/podinfo/values.yaml
   git add charts/podinfo/values.yaml
   git -c 'user.email=foo@bar.com' -c 'user.name=Foo' commit -m "Change replicaCount to 2"
 


### PR DESCRIPTION
This change fixes e2e tests on MacOS. Some of the tests use the `sed` command with the `-i` option to modify files in place. On Linux, that option has an optional parameter specifying the name of the back-up file to create. On the standard `sed` installation in MacOS, the parameter for `-i` is required (it may be empty though, in which case no back-up file is created), so the tests fail with this message:
```
# (in test file ./15_upgrade.bats, line 67)
#   `sed -i 's%replicaCount: 1%replicaCount: 2%' charts/podinfo/values.yaml' failed
```
 This change modifies sed invocation to work on MacOS. This should help with the development of Helm Operator on Mac.