### PR TITLE
Add `priorityClassName` value to Helm Operator

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -69,6 +69,7 @@ chart and their default values.
 | `nodeSelector`                                    | `{}`                                                 | Node Selector properties for the deployment
 | `tolerations`                                     | `[]`                                                 | Tolerations properties for the deployment
 | `affinity`                                        | `{}`                                                 | Affinity properties for the deployment
+| `priorityClassName`                               | `""`                                                 | Set priority class for Helm Operator
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Helm Operator pod(s)
 | `podAnnotations`                                  | `{}`                                                 | Additional pod annotations
 | `podLabels`                                       | `{}`                                                 | Additional pod labels
@@ -165,7 +166,7 @@ helm upgrade -i helm-operator fluxcd/helm-operator \
 ```
 
 After adding the entry, the Helm chart in the repository can then be referred
-to by the URL of the repository as usual: 
+to by the URL of the repository as usual:
 
 ```yaml
 apiVersion: helm.fluxcd.io/v1

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       app: {{ template "helm-operator.name" . }}
       release: {{ .Release.Name }}
   strategy:
-    type:  Recreate  
+    type:  Recreate
   template:
     metadata:
       annotations:
@@ -36,6 +36,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       serviceAccountName: {{ template "helm-operator.serviceAccountName" . }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -211,3 +211,4 @@ hostAliases: {}
 #   - "foo.remote"
 #   - "bar.remote"
 
+priorityClassName: ""


### PR DESCRIPTION
This is necessary in overcontended environments to help ensure the operator does not get evicted, or to allow it to preempt other workloads.

--

Pulled basically verbatim from the fluxcd chart.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
