### PR TITLE
Prepare chart-1.0.2 release

### DIFF
--- a/chart/helm-operator/Chart.yaml
+++ b/chart/helm-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.0.1"
-version: 1.0.1
+version: 1.0.2
 kubeVersion: ">=1.11.0-0"
 name: helm-operator
 description: Flux Helm Operator is a CRD controller for declarative helming

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -144,8 +144,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-# If create is `false`  the Helm Operator will be restricted to the namespace
-# where it is deployed, and no clusterRole or clusterRoleBinding will be created
+# If create is `false` the Helm Operator will be restricted to the namespace
+# where it is deployed, and no ClusterRole or ClusterRoleBinding will be created.
 # Additionally, the kubeconfig default context will be set to that namespace.
 clusterRole:
   create: true

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -144,7 +144,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-# If create is `false`  the Helm Operator will be restricted to the namespace 
+# If create is `false`  the Helm Operator will be restricted to the namespace
 # where it is deployed, and no clusterRole or clusterRoleBinding will be created
 # Additionally, the kubeconfig default context will be set to that namespace.
 clusterRole:


### PR DESCRIPTION
This contains two changes to the chart:

 - #402 which tidies up the creation of ClusterRole(Binding)s (NB: `clusterRole.create: false` now suppresses the creation of a ClusterRole and ClusterBinding, even if `clusterRole.name` is given a value)
 - #401 which adds a `priorityClassName` setting
