### PR TITLE
add SecurityContext for Pod

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -125,6 +125,7 @@ chart and their default values.
 | `prometheus.serviceMonitor.additionalLabels`      | `{}`                                                 | Additional labels to add to the ServiceMonitor
 | `initContainers`                                  | `[]`                                                 | Init containers and their specs
 | `hostAliases`                                     | `{}`                                                 | Host aliases allow the modification of the hosts file (`/etc/hosts`) inside Helm Operator container. See <https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/>
+| `podSecurityContext`                              | `{}`                                                 | SecurityContext to add to the Flux pod(s). See <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>
 
 ## How-to
 

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
       serviceAccountName: {{ template "helm-operator.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -211,3 +211,9 @@ hostAliases: {}
 #   - "bar.remote"
 
 priorityClassName: ""
+podSecurityContext: {}
+#  allowPrivilegeEscalation: false
+#  fsGroup: 1001
+#  runAsUser: 1001
+#  runAsGroup: 1001
+#  runAsNonRoot: true


### PR DESCRIPTION
When working with restrictive PSP, it enables to enforce lower permission with the securitycontext. A small example is provided in values.yaml

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
