### PR TITLE
Remove tabs from chart docs

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -26,7 +26,9 @@ kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/{{ versi
 
 Install the Helm operator using the chart:
 
-```sh tab="Default (Helm 2 and 3)"
+Chart defaults (Helm 2 and 3):
+
+```sh
 # Default with support for Helm 2 and 3 enabled
 # NB: the presence of Tiller is a requirement when
 # Helm 2 is enabled.
@@ -34,14 +36,18 @@ helm upgrade -i helm-operator fluxcd/helm-operator \
     --namespace flux
 ```
 
-```sh tab="Helm 3"
+Helm 3:
+
+```sh
 # Only Helm 3 support enabled using helm.versions
 helm upgrade -i helm-operator fluxcd/helm-operator \
     --namespace flux \
     --set helm.versions=v3
 ```
 
-```sh tab="Helm 2"
+Helm 2:
+
+```sh
 # Only Helm 2 support enabled using helm.versions
 # NB: the presence of Tiller is a requirement when
 # Helm 2 is enabled.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,6 @@ markdown_extensions:
       guess_lang: false
   - toc:
       permalink: true
-  - pymdownx.tabbed
 
 nav:
   - Overview: index.md


### PR DESCRIPTION
The SuperFences syntax which renders nicely on both GitHub and on the
documentation site itself has been deprecated and replaced by its
successor "tabbed". The tabbed syntax does not make it possible to
hide the tab titles on GitHub, which is a requirement for the chart
documentation page.