### PR TITLE
helm/v3: garbage collect anonymous index files

### DIFF
--- a/pkg/helm/v3/dependency.go
+++ b/pkg/helm/v3/dependency.go
@@ -1,12 +1,22 @@
 package v3
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"helm.sh/helm/v3/pkg/downloader"
 
 	"github.com/fluxcd/helm-operator/pkg/utils"
 )
 
 func (h *HelmV3) DependencyUpdate(chartPath string) error {
+	// Garbage collect before the dependency update so that
+	// anonymous files from previous runs are cleared, with
+	// a safe guard time offset to not touch any files in
+	// use.
+	garbageCollect(repositoryCache, time.Second * 120)
 	out := utils.NewLogWriter(h.logger)
 	man := &downloader.Manager{
 		Out:              out,
@@ -16,4 +26,22 @@ func (h *HelmV3) DependencyUpdate(chartPath string) error {
 		Getters:          getterProviders(),
 	}
 	return man.Update()
+}
+
+// garbageCollect walks over the files in the given path and deletes
+// any anonymous index file with a mod time older than the given
+// duration.
+func garbageCollect(path string, olderThan time.Duration) {
+	now := time.Now()
+	filepath.Walk(path, func(p string, f os.FileInfo, err error) error {
+		if err != nil || f.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(f.Name(), "=-index.yaml") || strings.HasSuffix(f.Name(), "=-charts.txt") {
+			if now.Sub(f.ModTime()) > olderThan {
+				return os.Remove(p)
+			}
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
The Helm 3 dependency update generates anonymous index files on every
run without garbage collecting them, resulting in spurious disk usage.
Configuring a temporary cache directory and garbage collecting it after
the dependency update is not possible as the download manager seems to
ignore the configured repository cache path and always create the index
file in the XDG cache directory.

Instead we detect the any anonymous index filex by their "=" suffix and
delete if they are older than 2m.