### PR TITLE
Upgrade version of example redis chart due to errors installing the 9.0.2 version of the chart.

### DIFF
--- a/chart/helm-operator/templates/NOTES.txt
+++ b/chart/helm-operator/templates/NOTES.txt
@@ -22,7 +22,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com
     name: redis
-    version: 9.0.2
+    version: 10.5.7
   valuesFrom:
   - secretKeyRef:
       name: redis-auth


### PR DESCRIPTION
Installing the example redis chart as specified in the `NOTES.txt` file fails on kubernetes versions `1.16` and newer due to the API changes that remove the deprecated `apps/v1beta2` version for StatefulSets. The `10.5.7` version of the chart works fine.

```
$ kubectl logs -f -l app=helm-operator
ts=2020-05-26T14:07:43.213850178Z caller=release.go:75 component=release release=redis targetNamespace=default resource=default:helmrelease/redis helmVersion=v3 info="starting sync run"
ts=2020-05-26T14:07:43.223158561Z caller=release.go:270 component=release release=redis targetNamespace=default resource=default:helmrelease/redis helmVersion=v3 info="running installation" phase=install
ts=2020-05-26T14:07:43.467891862Z caller=release.go:273 component=release release=redis targetNamespace=default resource=default:helmrelease/redis helmVersion=v3 error="installation failed: unable to build kubernetes objects from release manifest: unable to recognize \"\": no matches for kind \"StatefulSet\" in version \"apps/v1beta2\"" phase=install
ts=2020-05-26T14:07:43.474213791Z caller=release.go:325 component=release release=redis targetNamespace=default resource=default:helmrelease/redis helmVersion=v3 warning="uninstall failed: uninstall: Release not loaded: redis: release: not found" phase=uninstall
```

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
