### PR TITLE
Set `release_condition_info` labels properly

### DIFF
--- a/pkg/status/metrics.go
+++ b/pkg/status/metrics.go
@@ -38,8 +38,8 @@ func ObserveReleaseConditions(old v1.HelmRelease, new v1.HelmRelease) {
 	}
 	for conditionType, conditionStatus := range conditions {
 		releaseCondition.With(
-			LabelTargetNamespace, new.Namespace,
-			LabelReleaseName, new.Name,
+			LabelTargetNamespace, new.GetTargetNamespace(),
+			LabelReleaseName, new.GetReleaseName(),
 			LabelCondition, string(conditionType),
 		).Set(conditionStatusToGaugeValue[conditionStatus])
 	}


### PR DESCRIPTION
Hey there 👋

Both `target_namespace` and `release_name` were wrongly set using the HelmRelease metadata. It may be worth releasing this as a patch.