### PR TITLE
Correcting README.md for helm chart documentation for resource limits

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -70,7 +70,7 @@ chart and their default values.
 | `image.pullSecret`                                | `None`                                               | Image pull secret
 | `resources.requests.cpu`                          | `50m`                                                | CPU resource requests for the deployment
 | `resources.requests.memory`                       | `64Mi`                                               | Memory resource requests for the deployment
-| `resources.requests.cpu`                          | `None`                                               | CPU resource limits for the deployment
+| `resources.limits.cpu`                            | `None`                                               | CPU resource limits for the deployment
 | `resources.limits.memory`                         | `None`                                               | Memory resource limits for the deployment
 | `nodeSelector`                                    | `{}`                                                 | Node Selector properties for the deployment
 | `tolerations`                                     | `[]`                                                 | Tolerations properties for the deployment

--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -65,7 +65,6 @@ chart and their default values.
 | -----------------------------------------------   | ---------------------------------------------------- | ---
 | `image.repository`                                | `docker.io/fluxcd/helm-operator`                     | Image repository
 | `image.tag`                                       | `{{ version }}`                                      | Image tag
-| `replicaCount`                                    | `1`                                                  | Number of Helm Operator pods to deploy, more than one is not desirable
 | `image.pullPolicy`                                | `IfNotPresent`                                       | Image pull policy
 | `image.pullSecret`                                | `None`                                               | Image pull secret
 | `resources.requests.cpu`                          | `50m`                                                | CPU resource requests for the deployment


### PR DESCRIPTION
Helm Chart README.md contains incorrect value options. PR corrects the values for values.resource.limits


<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
