### PR TITLE
Roll deployment on update known_hosts

### DIFF
--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
     metadata:
       annotations:
         checksum/repositories: {{ include (print $.Template.BasePath "/helm-repositories.yaml") . | sha256sum | quote }}
+      {{- if .Values.git.ssh.known_hosts }}
+        checksum/ssh: {{ include (print $.Template.BasePath "/ssh.yaml") . | sha256sum | quote }}
+      {{- end }}
       {{- if .Values.prometheus.enabled }}
         prometheus.io/scrape: "true"
       {{- end }}
@@ -307,4 +310,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
-


### PR DESCRIPTION
add annotation when using known_hosts so deployments update properly

https://github.com/fluxcd/helm-operator/issues/440