### PR TITLE
docs: replace v1.13 API reference URLs with v1.18

### DIFF
--- a/docs/references/helmrelease-custom-resource.md
+++ b/docs/references/helmrelease-custom-resource.md
@@ -46,7 +46,7 @@ string
 <td>
 <code>metadata</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -744,7 +744,7 @@ ConditionStatus
 <td>
 <code>lastUpdateTime</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>
@@ -759,7 +759,7 @@ update of this condition.</p>
 <td>
 <code>lastTransitionTime</code><br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#time-v1-meta">
 Kubernetes meta/v1.Time
 </a>
 </em>

--- a/hack/crd-reference-doc-gen/config.json
+++ b/hack/crd-reference-doc-gen/config.json
@@ -14,7 +14,7 @@
     },
     {
       "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-      "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+      "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
     }
   ],
   "typeDisplayNamePrefixOverrides": {

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/fluxcd/helm-operator/hack/tools
 go 1.13
 
 require (
-	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5
+	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	golang.org/x/tools v0.0.0-20190927052746-69890759d905 // indirect
 	k8s.io/code-generator v0.17.2
 	k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -18,8 +18,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
-github.com/ahmetb/gen-crd-api-reference-docs v0.1.5 h1:OU+AFpBEhyclrQGx4I6zpCx5WvXiKqvFeeOASOmhKCY=
-github.com/ahmetb/gen-crd-api-reference-docs v0.1.5/go.mod h1:P/XzJ+c2+khJKNKABcm2biRwk2QAuwbLf8DlXuaL7WM=
+github.com/ahmetb/gen-crd-api-reference-docs v0.2.0 h1:YI/cAcRdNAHArfhGKcmCY5qMa32k/UyCZagLgabC5JY=
+github.com/ahmetb/gen-crd-api-reference-docs v0.2.0/go.mod h1:P/XzJ+c2+khJKNKABcm2biRwk2QAuwbLf8DlXuaL7WM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=


### PR DESCRIPTION
As they (the Kubernetes maintainers) decided to nuke all documentation
references prior to v1.18, resulting in dead links.
