### PR TITLE
Always dry run compare before upgrade

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -179,10 +179,6 @@ func HasSynced(hr *v1.HelmRelease) bool {
 // HasRolledBack returns if the current generation of the HelmRelease
 // has been rolled back.
 func HasRolledBack(hr *v1.HelmRelease) bool {
-	if !HasSynced(hr) {
-		return false
-	}
-
 	rolledBack := GetCondition(hr.Status, v1.HelmReleaseRolledBack)
 	if rolledBack == nil {
 		return false


### PR DESCRIPTION
Upgrades should only occur if there are non-trivial changes
since the previously applied (installed/upgraded) state, or
if this is the same state that was previously upgraded to
and rolled back from, and the HelmRelease config allows for
further upgrade attempts. Thus, a dry run compare should
always occur first to compare the current desired state to
the one previously applied. Previously, there were several
cases where superfluous upgrades could occur. There were
also cases where release diffs were not logged, since the
dry run compare never occurred.

As the included TODO indicates, this also enables a future
enhancement to reset the rollback count when non-trivial
changes are detected, so that the new state is alotted the
configured number of retries, regardless of any failed
attempts on a previous state.