### PR TITLE
Add info metric for release labels

### DIFF
--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -1,8 +1,14 @@
 package operator
 
 import (
+	"fmt"
+	"sync"
+
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics/prometheus"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
+
+	helmfluxv1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
 )
 
 var (
@@ -19,3 +25,98 @@ var (
 		Help:      "Count of releases managed by the operator.",
 	}, []string{})
 )
+
+const (
+	releaseLabelsName = "flux_helm_operator_release_labels"
+	releaseLabelsHelp = "HelmRelease object labels"
+)
+
+type collectorKey struct {
+	name            string
+	targetNamespace string
+}
+
+// labelCollector implements prometheus.Collector interface to generate label metrics
+type labelCollector struct {
+	logger log.Logger
+
+	sync.Mutex
+	releases map[collectorKey]map[string]string
+}
+
+func newLabelCollector(logger log.Logger) *labelCollector {
+	return &labelCollector{
+		logger:   logger,
+		releases: make(map[collectorKey]map[string]string),
+	}
+}
+
+var (
+	defaultLabels = []string{"release_name", "target_namespace"}
+)
+
+func (c *labelCollector) Describe(chan<- *stdprometheus.Desc) {
+	// Return nothing to signal unchecked collector (since we have varying labels)
+}
+func (c *labelCollector) Collect(ch chan<- stdprometheus.Metric) {
+	c.Lock()
+	defer c.Unlock()
+
+	for hr, labels := range c.releases {
+		labelNames := mapKeys(labels)
+		labelValues := mapValuesKeyOrdered(labels, labelNames)
+		desc := stdprometheus.NewDesc(releaseLabelsName, releaseLabelsHelp, append(labelNames, defaultLabels...), nil)
+		metric, err := stdprometheus.NewConstMetric(
+			desc,
+			stdprometheus.GaugeValue,
+			1,
+			append(labelValues, hr.name, hr.targetNamespace)...,
+		)
+		if err != nil {
+			c.logger.Log("error", fmt.Sprintf("could not generate label metric: %s", err))
+			continue
+		}
+		ch <- metric
+	}
+}
+func (c *labelCollector) Add(hr helmfluxv1.HelmRelease) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.releases[newCollectorKey(hr)] = generateLabelMap(hr.Labels)
+}
+func (c *labelCollector) Remove(hr helmfluxv1.HelmRelease) {
+	c.Lock()
+	defer c.Unlock()
+
+	delete(c.releases, newCollectorKey(hr))
+}
+
+func generateLabelMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out["label_"+k] = v
+	}
+	return out
+}
+
+func newCollectorKey(hr helmfluxv1.HelmRelease) collectorKey {
+	return collectorKey{
+		name:            hr.Name,
+		targetNamespace: hr.GetTargetNamespace(),
+	}
+}
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+func mapValuesKeyOrdered(m map[string]string, orderedKeys []string) []string {
+	vals := make([]string, 0, len(m))
+	for _, k := range orderedKeys {
+		vals = append(vals, m[k])
+	}
+	return vals
+}


### PR DESCRIPTION
This PR adds informational metrics about the `HelmRelease` object, for example:

```
flux_helm_operator_release_labels{label_foo="florp",label_hej="hopp",release_name="my-release",target_namespace="some-ns"} 1
flux_helm_operator_release_labels{label_baz="qux",label_foo="bar",release_name="another-release",target_namespace="default"} 1
```

This goes along the lines of the metrics exposed by kube-state-metrics, and is useful to join in with the conditions metric for alerting (eg a team label in our case).

I'm not quite sure I like the wiring-up bits in the operator itself, please have an extra look at what you think there. 

Signed-off-by: Calle Pettersson <calle@cape.nu>

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->