### PR TITLE
Allow installs to proceed if no v2 and v3 release exists during migration

### DIFF
--- a/pkg/helm/v3/converter.go
+++ b/pkg/helm/v3/converter.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"strings"
+
 	"github.com/helm/helm-2to3/pkg/common"
 	helm2 "github.com/helm/helm-2to3/pkg/v2"
 	helm3 "github.com/helm/helm-2to3/pkg/v3"
@@ -22,7 +24,10 @@ func (c Converter) V2ReleaseExists(releaseName string) (bool, error) {
 		File: c.KubeConfig,
 	}
 	v2Releases, err := helm2.GetReleaseVersions(retrieveOpts, kubeConfig)
-	if err != nil {
+
+	// We check for the error message content because
+	// Helm 2to3 returns an error if it doesn't find release versions
+	if err != nil && !strings.Contains(err.Error(), "has no deployed releases") {
 		return false, err
 	}
 	return len(v2Releases) > 0, nil

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -218,7 +218,7 @@ func (r *Release) determineSyncAction(client helm.Client, hr *apiV1.HelmRelease,
 			case string(apiV1.HelmV3):
 				v2ReleaseExists, err := r.converter.V2ReleaseExists(hr.GetReleaseName())
 				if err != nil {
-					return SkipAction, nil, fmt.Errorf("failed to retrieve Helm v2 release whil attempting migration: %w", err)
+					return SkipAction, nil, fmt.Errorf("failed to retrieve Helm v2 release while attempting migration: %w", err)
 				}
 				if v2ReleaseExists {
 					return MigrateAction, nil, nil

--- a/test/e2e/fixtures/releases/convert-2to3-v3-upgrade.yaml
+++ b/test/e2e/fixtures/releases/convert-2to3-v3-upgrade.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: podinfo-helm-repository
+  namespace: demo
+  annotations:
+    helm.fluxcd.io/migrate: "true"
+spec:
+  helmVersion: v3
+  releaseName: podinfo-helm-repository
+  timeout: 30
+  test:
+    enable: true
+    timeout: 30
+  rollback:
+    enable: true
+    wait: true
+  chart:
+    repository: https://stefanprodan.github.io/podinfo
+    name: podinfo
+    version: 4.0.1
+  values:
+    replicaCount: 1


### PR DESCRIPTION
* When rolling out migrations across many clusters, there could be some new helm releases that were migrated. For example, if we have DEV, UAT, and PROD environments; DEV might have already migrated v2 to v3 releases, UAT might still need to do the migration, while PROD might not have had the v2 releases at all. This bugfix allows all 3 scenarios to work as expected.