### PR TITLE
Support tiller-less migrations

### DIFF
--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -256,6 +256,12 @@ spec:
         {{- if .Values.tls.hostname }}
         - --tiller-tls-hostname={{ .Values.tls.hostname }}
         {{- end }}
+        {{- if .Values.convert.releaseStorage }}
+        - --convert-release-storage={{ .Values.convert.releaseStorage }}
+        {{- end }}
+        {{- if .Values.convert.tillerOutCluster }}
+        - --convert-tiller-out-cluster={{ .Values.convert.tillerOutCluster }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -50,6 +50,11 @@ tls:
   caContent: ""
   hostname: ""
 
+# available options when converting from helm 2 to 3
+convert:
+  releaseStorage: "secrets"
+  tillerOutCluster: false
+
 # ADVANCED: Allow for deploying Tiller as a sidecar (restricted to 'localhost' for security reasons).
 # When enabled, either .clusterRole.create should be true or .clusterRole.name should be set to the name of a cluster role granting the required privileges.
 # Please make extra sure you know what you are doing before enabling this. :)

--- a/docs/helmrelease-guide/release-configuration.md
+++ b/docs/helmrelease-guide/release-configuration.md
@@ -47,6 +47,11 @@ spec:
     name: redis
 ```
 
+3. Assuming you will be deleting the tiller deployment using gitops, consider
+setting the operator flags `--convert-tiller-out-cluster=true` and
+`--convert-release-storage=configmaps`. If tiller is in a custom namespace, make
+sure you set `--tiller-namespace=` flag as well.
+
 After applying the new HelmRelease, the operator will take care of deleting the
 old v2 release that Tiller managed and converting it to the v3 format. Once
 you're satisfied with the migration, you can go ahead and remove the

--- a/docs/references/operator.md
+++ b/docs/references/operator.md
@@ -65,6 +65,13 @@ enabled and a connection to Tiller needs to be made.
 | `--tiller-tls-ca-cert-path` |                               | Path to CA certificate file used to validate the Tiller server. Required if `--tiller-tls-verify` is enabled.
 | `--tiller-tls-hostname`     |                               | The server name used to verify the hostname on the returned certificates from the Tiller server.
 
+#### Helm 2to3 convert configurations
+
+| Flag                           | Default                       | Purpose
+| --------------------------     | ----------------------------- | ---
+| `--convert-release-storage`    | `secrets`                     | v2 release storage type/object. It can be 'secrets' or 'configmaps'. This is only used with the 'tiller-out-cluster' flag (default 'secrets')
+| `--convert-tiller-out-cluster` | `false`                       | When Tiller is not running in the cluster e.g. Tillerless
+
 ### Git chart source configuration
 
 | Flag                        | Default                       | Purpose

--- a/pkg/helm/v3/converter.go
+++ b/pkg/helm/v3/converter.go
@@ -10,15 +10,19 @@ import (
 
 // Converter Converts a given helm 2 release with all its release versions to helm 3 format and deletes the old release from tiller
 type Converter struct {
-	TillerNamespace string
-	KubeConfig      string // file path to kubeconfig
+	TillerNamespace  string
+	KubeConfig       string // file path to kubeconfig
+	TillerOutCluster bool
+	StorageType      string
 }
 
 // V2ReleaseExists helps you check if a helm v2 release exists or not
 func (c Converter) V2ReleaseExists(releaseName string) (bool, error) {
 	retrieveOpts := helm2.RetrieveOptions{
-		ReleaseName:     releaseName,
-		TillerNamespace: c.TillerNamespace,
+		ReleaseName:      releaseName,
+		TillerNamespace:  c.TillerNamespace,
+		TillerOutCluster: c.TillerOutCluster,
+		StorageType:      c.StorageType,
 	}
 	kubeConfig := common.KubeConfig{
 		File: c.KubeConfig,


### PR DESCRIPTION
Assuming users will be deleting the tiller deployment using gitops, they might need to set the 2to3 plugin flags `--tiller-out-cluster=true` and `--release-storage=configmaps`.
This PR exposes those flags as `--convert-tiller-out-cluster` and `--convert-release-storage`