### PR TITLE
Fix cast panic in operator.go

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -98,7 +98,7 @@ func New(
 			if hr, ok := checkCustomResourceType(controller.logger, old); ok {
 				releaseCount.Add(-1)
 				controller.release.Uninstall(hr.DeepCopy())
-				status.ObserveReleaseConditions(old.(helmfluxv1.HelmRelease), nil)
+				status.ObserveReleaseConditions(hr, nil)
 			}
 		},
 	})


### PR DESCRIPTION
Objects given to informed add/update/delete events are always pointers to structs, so a cast of that object to a struct (without the pointer) will always result in a panic.
In the case of this deletefunc, we've already cast the object to a pointer in `checkCustomResourceType` and returned the struct alone, so just use that in the `status.ObserveReleaseConditions` call

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
cc @hiddeco 