### PR TITLE
Resolve panic on delete and improve tests

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -97,8 +97,10 @@ func New(
 		DeleteFunc: func(old interface{}) {
 			if hr, ok := checkCustomResourceType(controller.logger, old); ok {
 				releaseCount.Add(-1)
-				controller.release.Uninstall(hr.DeepCopy())
-				status.ObserveReleaseConditions(hr, nil)
+				if err := controller.release.Uninstall(hr.DeepCopy()); err != nil {
+					controller.logger.Log("error", err)
+				}
+				status.ObserveReleaseConditions(&hr, nil)
 			}
 		},
 	})

--- a/pkg/status/conditions.go
+++ b/pkg/status/conditions.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/clock"
 
-	"github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
+	v1 "github.com/fluxcd/helm-operator/pkg/apis/helm.fluxcd.io/v1"
 	v1client "github.com/fluxcd/helm-operator/pkg/client/clientset/versioned/typed/helm.fluxcd.io/v1"
 )
 
@@ -55,7 +55,7 @@ func SetConditions(client v1client.HelmReleaseInterface, hr *v1.HelmRelease, con
 			setter(cHr)
 		}
 
-		ObserveReleaseConditions(*hr, cHr)
+		ObserveReleaseConditions(hr, cHr)
 		_, err = client.UpdateStatus(cHr)
 		firstTry = false
 		return

--- a/test/e2e/10_helm_chart.bats
+++ b/test/e2e/10_helm_chart.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 function setup() {
-  # Load libraries in setup() to access BATS_* variables 
+  # Load libraries in setup() to access BATS_* variables
   load lib/env
   load lib/install
   load lib/poll
@@ -31,11 +31,18 @@ function setup() {
   poll_until_equals 'git chart released condition true' 'True' "kubectl -n $DEMO_NAMESPACE get helmrelease/podinfo-git -o jsonpath='{.status.conditions[?(@.type==\"Released\")].status}'"
   run kubectl -n $DEMO_NAMESPACE get helmrelease/podinfo-git -o jsonpath='{.status.conditions[?(@.type=="Deployed")].status}'
   [ "$output" = 'True' ]
+
+  poll_no_restarts
 }
 
 function teardown() {
   # Teardown is verbose when a test fails, and this will help most of the time
   # to determine _why_ it failed.
+  echo ""
+  echo "### Previous container:"
+  kubectl logs -n "$E2E_NAMESPACE" deploy/helm-operator -p
+  echo ""
+  echo "### Current container:"
   kubectl logs -n "$E2E_NAMESPACE" deploy/helm-operator
 
   # Removing the operator also takes care of the global resources it installs.

--- a/test/e2e/25_max_history.bats
+++ b/test/e2e/25_max_history.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 function setup() {
-  # Load libraries in setup() to access BATS_* variables 
+  # Load libraries in setup() to access BATS_* variables
   load lib/env
   load lib/install
   load lib/poll
@@ -32,6 +32,8 @@ function setup() {
   # Check count of revisions is <= 10
   count=$(helm history podinfo-helm-repository --namespace "$DEMO_NAMESPACE" --skip-headers | tail -n +2 | wc -l)
   [ "$count" -eq 10 ]
+
+  poll_no_restarts
 }
 
 @test "When max history on release is set to 5 the most recent 5 revisions are kept" {
@@ -57,11 +59,18 @@ function setup() {
   # Check count of revisions is <= 5
   count=$(helm history podinfo-helm-repository --namespace "$DEMO_NAMESPACE" --skip-headers | tail -n +2 | wc -l)
   [ "$count" -eq 5 ]
+
+  poll_no_restarts
 }
 
 function teardown() {
   # Teardown is verbose when a test fails, and this will help most of the time
   # to determine _why_ it failed.
+  echo ""
+  echo "### Previous container:"
+  kubectl logs -n "$E2E_NAMESPACE" deploy/helm-operator -p
+  echo ""
+  echo "### Current container:"
   kubectl logs -n "$E2E_NAMESPACE" deploy/helm-operator
 
   # Removing the operator also takes care of the global resources it installs.

--- a/test/e2e/30_values_from.bats
+++ b/test/e2e/30_values_from.bats
@@ -54,6 +54,8 @@ EOF
 
   # Wait for release recovery
   poll_until_equals 'recovery after adding config map in namespace' 'True' "kubectl -n $DEMO_NAMESPACE get helmrelease/configmap-values -o jsonpath='{.status.conditions[?(@.type==\"Released\")].status}'"
+
+  poll_no_restarts
 }
 
 @test "When valuesFrom.secretKeyRefs are defined, they are sourced" {
@@ -96,6 +98,8 @@ EOF
 
   # Wait for release recovery
   poll_until_equals 'recovery after adding secret in namespace' 'True' "kubectl -n $DEMO_NAMESPACE get helmrelease/secret-values  -o jsonpath='{.status.conditions[?(@.type==\"Released\")].status}'"
+
+  poll_no_restarts
 }
 
 @test "When valuesFrom.externalSourceRefs are defined, they are sourced" {
@@ -116,6 +120,8 @@ EOF
 
   # Wait for release recovery
   poll_until_equals 'recovery after making external source optional' 'True' "kubectl -n $DEMO_NAMESPACE get helmrelease/external-source-values -o jsonpath='{.status.conditions[?(@.type==\"Released\")].status}'"
+
+  poll_no_restarts
 }
 
 @test "When valuesFrom.chartFileRefs are defined, they are sourced" {
@@ -137,6 +143,7 @@ EOF
   # Wait for release recovery
   poll_until_equals 'recovery after making chart file optional' 'True' "kubectl -n $DEMO_NAMESPACE get helmrelease/chartfile-values -o jsonpath='{.status.conditions[?(@.type==\"Released\")].status}'"
 
+  poll_no_restarts
 }
 
 function teardown() {
@@ -144,6 +151,11 @@ function teardown() {
 
   # Teardown is verbose when a test fails, and this will help most of the time
   # to determine _why_ it failed.
+  echo ""
+  echo "### Previous container:"
+  kubectl logs -n "$E2E_NAMESPACE" deploy/helm-operator -p
+  echo ""
+  echo "### Current container:"
   kubectl logs -n "$E2E_NAMESPACE" deploy/helm-operator
 
   # Removing the operator also takes care of the global resources it installs.

--- a/test/e2e/lib/poll.bash
+++ b/test/e2e/lib/poll.bash
@@ -28,3 +28,8 @@ function poll_until_true() {
   done
   echo ' done' >&3
 }
+
+function poll_no_restarts() {
+  sleep 5 # allow enough time for the operator to react to previous operation
+  poll_until_equals 'no helm-operator restarts' '0' "kubectl get pod -n $E2E_NAMESPACE -l app=helm-operator -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}'" '1'
+}


### PR DESCRIPTION
* Fix #493 panic on deletes and improve delete error handling
* tests
	* add test that was failing without the changes and passed after adding changes
	* Wait for tiller to be READY
    * Add new poll function `poll_no_restarts` and use it to check at the end of every test if a restart occurred in the operator
    * Show logs of previous shut down container to help in debugging failures