### PR TITLE
Looping over namespaces for rbac creation as in flux chart

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -107,6 +107,7 @@ chart and their default values.
 | `logFormat`                                       | `fmt`                                                | Log format (fmt or json)
 | `logReleaseDiffs`                                 | `false`                                              | Helm Operator should log the diff when a chart release diverges (possibly insecure)
 | `allowNamespace`                                  | `None`                                               | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched
+| `allowedNamespaces`                               | `[]`                                                 | Allow helm-operator to manage resources in the specified namespaces. The namespace flux is deployed in will always be included
 | `helm.versions`                                   | `v2,v3`                                              | Helm versions supported by this operator instance, if v2 is specified then Tiller is required
 | `tillerNamespace`                                 | `kube-system`                                        | Namespace in which the Tiller server can be found
 | `tillerSidecar.enabled`                           | `false`                                              | Whether to deploy Tiller as a sidecar (and listening on `localhost` only).

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -231,7 +231,7 @@ spec:
         {{- if .Values.workers }}
         - --workers={{ .Values.workers }}
         {{- end }}
-        {{- if not .Values.clusterRole.create }}
+        {{- if (and  (not .Values.clusterRole.create) ( not .Values.allowedNamespaces)) }}
         - --allow-namespace={{ .Release.Namespace }}
         {{- else if .Values.allowNamespace }}
         - --allow-namespace={{ .Values.allowNamespace }}

--- a/chart/helm-operator/templates/rbac-role.yaml
+++ b/chart/helm-operator/templates/rbac-role.yaml
@@ -1,13 +1,15 @@
 {{- if and .Values.rbac.create (eq .Values.clusterRole.create false) -}}
+{{- range $namespace := (append .Values.allowedNamespaces .Release.Namespace) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: {{ template "helm-operator.fullname" . }}
+  name: {{ template "helm-operator.fullname" $ }}
+  namespace: {{ $namespace }}
   labels:
-    app: {{ template "helm-operator.name" . }}
-    chart: {{ template "helm-operator.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app: {{ template "helm-operator.name" $ }}
+    chart: {{ template "helm-operator.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
 rules:
   - apiGroups:
       - '*'
@@ -19,19 +21,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: {{ template "helm-operator.fullname" . }}
+  name: {{ template "helm-operator.fullname" $ }}
+  namespace: {{ $namespace }}
   labels:
-    app: {{ template "helm-operator.name" . }}
-    chart: {{ template "helm-operator.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app: {{ template "helm-operator.name" $ }}
+    chart: {{ template "helm-operator.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "helm-operator.fullname" . }}
+  name: {{ template "helm-operator.fullname" $ }}
 subjects:
-  - name: {{ template "helm-operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+  - name: {{ template "helm-operator.serviceAccountName" $ }}
+    namespace: {{ $.Release.Namespace | quote }}
     kind: ServiceAccount
 ---
+{{- end }}
 {{- end -}}

--- a/chart/helm-operator/templates/rbac.yaml
+++ b/chart/helm-operator/templates/rbac.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.rbac.create (eq .Values.clusterRole.create true) -}}
+{{- if and .Values.rbac.create -}}
+{{ if .Values.clusterRole.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -19,6 +20,8 @@ rules:
       - '*'
     verbs:
       - '*'
+{{- end -}}
+{{- if or .Values.clusterRole.create .Values.clusterRole.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -37,4 +40,5 @@ subjects:
   - name: {{ template "helm-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
+{{- end -}}
 {{- end -}}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -17,6 +17,8 @@ service:
 createCRD: false
 # Limit the operator scope to a single namespace
 allowNamespace:
+# Specifies which namespaces helm-operator should have access to
+allowedNamespaces: []
 # Update dependencies for charts
 updateChartDeps: true
 # Log format can be fmt or json


### PR DESCRIPTION
In order to be able to create roles in multiple namespaces instead of a single admin clusterrole I've introduced the same logic implemented for flux's helm chart.

- added an `allowedNamespaces` parameter to the values with the list of allowed namespaces
- added logic to create role and rolebinding in all namespaces specified

In order to have full feature parity between flux and helm-operator the `--k8s-allow-namespaces` flag should be added, let me know if i can start working on that too.