### PR TITLE
Compare dry-run and release manifests to determine upgrades.

### DIFF
--- a/pkg/helm/utils.go
+++ b/pkg/helm/utils.go
@@ -5,5 +5,5 @@ import (
 )
 
 func Diff(j *Release, k *Release) string {
-	return cmp.Diff(j.Values, k.Values) + cmp.Diff(j.Chart, k.Chart)
+	return cmp.Diff(j.Values, k.Values) + cmp.Diff(j.Chart, k.Chart) + cmp.Diff(j.Manifest, k.Manifest)
 }


### PR DESCRIPTION
Fixes #16 

If applied, this commit will allow helm-operator, on `dryRunCompare`, to notice changes made to child charts. This will not permit spurious upgrades.