### PR TITLE
[Helm Test] Continuous helm test parameter

### DIFF
--- a/chart/helm-operator/crds/helmrelease.yaml
+++ b/chart/helm-operator/crds/helmrelease.yaml
@@ -206,6 +206,9 @@ spec:
                     to delete test pods between each test run initiated by the Helm
                     Operator.
                   type: boolean
+                continuous:
+                  description: Set Continuous to true will run test continuously.
+                  type: boolean
                 enable:
                   description: Enable will mark this Helm release for tests.
                   type: boolean
@@ -218,9 +221,6 @@ spec:
                     operation (like Jobs for hooks) during test.
                   type: integer
                   format: int64
-                continuous:
-                  description: Set Continuous to true will run test continuously.
-                  type: boolean
             timeout:
               description: Timeout is the time to wait for any individual Kubernetes
                 operation (like Jobs for hooks) during installation and upgrade operations.

--- a/chart/helm-operator/crds/helmrelease.yaml
+++ b/chart/helm-operator/crds/helmrelease.yaml
@@ -218,6 +218,9 @@ spec:
                     operation (like Jobs for hooks) during test.
                   type: integer
                   format: int64
+                continuous:
+                  description: Set Continuous to true will run test continuously.
+                  type: boolean
             timeout:
               description: Timeout is the time to wait for any individual Kubernetes
                 operation (like Jobs for hooks) during installation and upgrade operations.

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -219,9 +219,6 @@ spec:
                     operation (like Jobs for hooks) during test.
                   type: integer
                   format: int64
-                continuous:
-                  description: Set Continuous to true will run test continuously.
-                  type: boolean
             timeout:
               description: Timeout is the time to wait for any individual Kubernetes
                 operation (like Jobs for hooks) during installation and upgrade operations.

--- a/deploy/crds.yaml
+++ b/deploy/crds.yaml
@@ -219,6 +219,9 @@ spec:
                     operation (like Jobs for hooks) during test.
                   type: integer
                   format: int64
+                continuous:
+                  description: Set Continuous to true will run test continuously.
+                  type: boolean
             timeout:
               description: Timeout is the time to wait for any individual Kubernetes
                 operation (like Jobs for hooks) during installation and upgrade operations.

--- a/docs/references/helmrelease-custom-resource.md
+++ b/docs/references/helmrelease-custom-resource.md
@@ -1783,6 +1783,18 @@ bool
 test pods between each test run initiated by the Helm Operator.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>continuous</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Set Continuous to true will run test continuously.</p>
+</td>
+</tr>
 </tbody>
 </table>
 </div>

--- a/pkg/apis/helm.fluxcd.io/v1/types_helmrelease.go
+++ b/pkg/apis/helm.fluxcd.io/v1/types_helmrelease.go
@@ -338,6 +338,9 @@ type Test struct {
 	// test pods between each test run initiated by the Helm Operator.
 	// +optional
 	Cleanup *bool `json:"cleanup,omitempty"`
+	// Set Continuous to true will run test continuously.
+	// +optional
+	Continuous bool `json:"continuous,omitempty"`
 }
 
 // IgnoreFailures returns the configured ignoreFailures flag,

--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -25,20 +25,20 @@ type StatusOptions struct {
 // fields supported by that version but can (silently) ignore
 // unsupported set values.
 type UpgradeOptions struct {
-	Namespace    string
-	Timeout      time.Duration
-	Wait         bool
-	Install      bool
-	DisableHooks bool
-	DryRun       bool
-	ClientOnly   bool
-	Force        bool
-	ResetValues  bool
-	SkipCRDs     bool
-	ReuseValues  bool
-	Recreate     bool
-	MaxHistory   int
-	Atomic       bool
+	Namespace         string
+	Timeout           time.Duration
+	Wait              bool
+	Install           bool
+	DisableHooks      bool
+	DryRun            bool
+	ClientOnly        bool
+	Force             bool
+	ResetValues       bool
+	SkipCRDs          bool
+	ReuseValues       bool
+	Recreate          bool
+	MaxHistory        int
+	Atomic            bool
 	DisableValidation bool
 }
 
@@ -77,6 +77,7 @@ type UninstallOptions struct {
 	DryRun       bool
 	KeepHistory  bool
 	Timeout      time.Duration
+	Continuous   bool
 }
 
 // HistoryOption holds the options available for Helm history

--- a/pkg/install/templates/crds.yaml.tmpl
+++ b/pkg/install/templates/crds.yaml.tmpl
@@ -207,6 +207,9 @@ spec:
                     to delete test pods between each test run initiated by the Helm
                     Operator.
                   type: boolean
+                continuous:
+                  description: Set Continuous to true will run test continuously.
+                  type: boolean
                 enable:
                   description: Enable will mark this Helm release for tests.
                   type: boolean
@@ -219,9 +222,6 @@ spec:
                     operation (like Jobs for hooks) during test.
                   type: integer
                   format: int64
-                continuous:
-                  description: Set Continuous to true will run test continuously.
-                  type: boolean
             timeout:
               description: Timeout is the time to wait for any individual Kubernetes
                 operation (like Jobs for hooks) during installation and upgrade operations.

--- a/pkg/install/templates/crds.yaml.tmpl
+++ b/pkg/install/templates/crds.yaml.tmpl
@@ -219,6 +219,9 @@ spec:
                     operation (like Jobs for hooks) during test.
                   type: integer
                   format: int64
+                continuous:
+                  description: Set Continuous to true will run test continuously.
+                  type: boolean
             timeout:
               description: Timeout is the time to wait for any individual Kubernetes
                 operation (like Jobs for hooks) during installation and upgrade operations.

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -309,6 +309,11 @@ next:
 			status.SetStatusPhase(r.hrClient.HelmReleases(hr.Namespace), hr, apiV1.HelmReleasePhaseSucceeded)
 		}
 		logger.Log("info", "no changes", "phase", action)
+		if hr.Spec.Test.Enable && hr.Spec.Test.Continuous == true {
+			logger.Log("info", "Triggering continuous test", "phase", action)
+			action = TestAction
+			goto next
+		}
 	case InstallAction:
 		logger.Log("info", "running installation", "phase", action)
 		newRel, err = r.install(client, hr, chart, values)


### PR DESCRIPTION
Hello,
This PR is about adding a continuous Helm test feature to trigger tests on a regular basis.

1. Added Continuous definitions in crds and go structures
```
continuous:
    description: Set Continuous to true will run test continuously.
    type: boolean
```

2. Trigger test if test and continuous parameters are enabled
```
 if hr.Spec.Test.Enable && hr.Spec.Test.Continuous == true {
	logger.Log("info", "Triggering continuous test", "phase", action)
	action = TestAction
	goto next
}
```


<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
