### PR TITLE
Default kubeconfig to None in chart

### DIFF
--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -162,19 +162,20 @@ clusterRole:
 
 kube:
   # Override for kubectl default config
-  config: |
-    apiVersion: v1
-    clusters: []
-    contexts:
-    - context:
-        cluster: ""
-        namespace: default
-        user: ""
-      name: default
-    current-context: default
-    kind: Config
-    preferences: {}
-    users: []
+  config: ""
+  # config: |
+  #   apiVersion: v1
+  #   clusters: []
+  #   contexts:
+  #   - context:
+  #       cluster: ""
+  #       namespace: default
+  #       user: ""
+  #     name: default
+  #   current-context: default
+  #   kind: Config
+  #   preferences: {}
+  #   users: []
 
 prometheus:
   enabled: false


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->

https://github.com/fluxcd/helm-operator/pull/507 Introduced a small regression. It doesn't look like a breaking change, but the chart documentation does still specify that the default kube config is "None" and this is not the case in 1.2.0. While the default kubeconfig seems harmless it doesn't reflect what has happened pre 1.2.0 and what is currently in the [README.md](https://github.com/fluxcd/helm-operator/blame/master/chart/helm-operator/README.md#L131) 

This PR reverts to pre 1.2.0 kube.config.

In 1.2.0 the chart uses the config map by default, even when the documentation says it doesn't as shown in the diff below.
In my proposed change the config map is removed (#507) and everything else stays exactly the same as shown in second diff.
```
diff template1.1.0-yaml template1.2.0-yaml 
9c9
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
47c47
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
69c69
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
88c88
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
109c109
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
129a130,133
>       - name: config
>         configMap:
>           name: RELEASE-NAME-helm-operator-kube-config
>           defaultMode: 0600
159a164,166
>         - name: config
>           mountPath: /root/.kube
>           readOnly: true
164a172
>         - --kubeconfig=/root/.kube/config
```
```
diff template1.1.0-yaml template-proposed.yaml 
9c9
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
27,38d26
<     apiVersion: v1
<     clusters: []
<     contexts:
<     - context:
<         cluster: ""
<         namespace: default
<         user: ""
<       name: default
<     current-context: default
<     kind: Config
<     preferences: {}
<     users: []
47c35
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
69c57
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
88c76
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0
109c97
<     chart: helm-operator-1.1.0
---
>     chart: helm-operator-1.2.0

```

templates were generated using `helm template .`