### PR TITLE
Unnest convert settings from tls

### DIFF
--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -268,6 +268,12 @@ spec:
         {{- else }}
         - --tiller-namespace={{ .Values.tillerNamespace }}
         {{- end }}
+        {{- if .Values.convert.releaseStorage }}
+        - --convert-release-storage={{ .Values.convert.releaseStorage }}
+        {{- end }}
+        {{- if .Values.convert.tillerOutCluster }}
+        - --convert-tiller-out-cluster={{ .Values.convert.tillerOutCluster }}
+        {{- end }}
         {{- if .Values.tls.enable }}
         - --tiller-tls-enable={{ .Values.tls.enable }}
         - --tiller-tls-key-path=/etc/fluxd/helm/{{ .Values.tls.keyFile }}
@@ -277,12 +283,6 @@ spec:
         - --tiller-tls-ca-cert-path=/etc/fluxd/helm-ca/ca.crt
         {{- if .Values.tls.hostname }}
         - --tiller-tls-hostname={{ .Values.tls.hostname }}
-        {{- end }}
-        {{- if .Values.convert.releaseStorage }}
-        - --convert-release-storage={{ .Values.convert.releaseStorage }}
-        {{- end }}
-        {{- if .Values.convert.tillerOutCluster }}
-        - --convert-tiller-out-cluster={{ .Values.convert.tillerOutCluster }}
         {{- end }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
The `convert` related arguments were nested in a couple `tls` conditions. This pull request unnests the `convert` arguments from the `tls` conditions.