### PR TITLE
Add aggregated clusterroles for helmreleases

### DIFF
--- a/chart/helm-operator/templates/rbac.yaml
+++ b/chart/helm-operator/templates/rbac.yaml
@@ -37,4 +37,49 @@ subjects:
   - name: {{ template "helm-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "helm-operator.clusterRoleName" . }}-view
+  labels:
+    app: {{ template "helm-operator.name" . }}
+    chart: {{ template "helm-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - helm.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "helm-operator.clusterRoleName" . }}-edit
+  labels:
+    app: {{ template "helm-operator.name" . }}
+    chart: {{ template "helm-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - helm.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
 {{- end -}}


### PR DESCRIPTION
These two clusterroles gets aggregated via a label into the default
ClusterRole "view", "edit" and "admin" which are provided by kubernetes
itself.
Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/

Inspired by [cert-manager](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/templates/rbac.yaml) from jetstack we provide this feature here as
well to make HelmReleases readable for everyone with view permissions
and editable for everyone with edit or admin permissions.

I get here because I started using [opsgenie/kubernetes-event-exporter](https://github.com/opsgenie/kubernetes-event-exporter) which uses the view privileges for getting the involvedObject metadata.
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
