### PR TITLE
Move Fons to maintainer emeritus

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,7 +4,12 @@ https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages
 
 In alphabetical order:
 
-Alfonso Acosta, Weaveworks <fons@weave.works> (github: @2opremio, slack: fons)
 Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
 Michael Bridgen, Weaveworks <michael@weave.works> (github: @squaremo, slack: Michael Bridgen)
 Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
+
+Retired maintainers:
+
+- Alfonso Acosta
+
+Thank you for your involvement, and let us not say "farewell" ...


### PR DESCRIPTION
Fons moved on from Weaveworks and in the past half year got busy with other projects since then (which is entirely understandable).

I personally want to thank Fons for all of his involvement in the Flux family of projects and wish him all the best!