### PR TITLE
doc fix: Malformed list in Chart sources -> Git repositories

### DIFF
--- a/docs/helmrelease-guide/chart-sources.md
+++ b/docs/helmrelease-guide/chart-sources.md
@@ -306,10 +306,9 @@ spec:
 The definition of the listed keys is as follows:
 
 * `git`: The URL of the Git repository, e.g. `git@github.com:org/repo` or
-   `https://github.com/org/repo.git`.
-  
-  **Note:** specifying a custom port only works when the protocol is specified,
-  e.g. `ssh://git@github.com:2222/org/repo.git` and not `git@github.com:2222/org/repo`.
+   `https://github.com/org/repo.git`. **Note:** specifying a custom port only
+   works when the protocol is specified,
+   e.g. `ssh://git@github.com:2222/org/repo.git` and not `git@github.com:2222/org/repo`.
 * `ref` _(Optional)_: The Git reference, e.g. a branch, tag, or (short) commit
    hash. When omitted, defaults to `master` or the configured `--git-default-ref`.
 * `path`: The path of the chart relative to the root of the Git repository.


### PR DESCRIPTION
The "_The definition of the listed keys is as follows_" on the _Chart sources_ is malformed when its rendered. As per [here](https://docs.fluxcd.io/projects/helm-operator/en/latest/helmrelease-guide/chart-sources/#git-repositories) and this screen grab:

<img width="858" alt="helm screen grab" src="https://user-images.githubusercontent.com/609476/95116144-7e1b0980-073e-11eb-9679-5cc703b8c37d.png">

The list should display as three items.

<!--
# Notice

The Helm Operator is in maintenance mode, and it will take a bit
longer until we get around to issues and PRs.
      
For more information, and details about the Helm Operator's future,
see: https://github.com/fluxcd/helm-operator/issues/546 

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
