### PR TITLE
fix: make passing gitconfig as a value optional

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -99,7 +99,8 @@ chart and their default values.
 | `git.ssh.configMapName`                           | `None`                                               | The name of a kubernetes config map containing the ssh config
 | `git.ssh.configMapKey`                            | `config`                                             | The name of the key in the kubernetes config map specified above
 | `git.config.enabled`                              | `false`                                              | If `true`, mount the .gitconfig into the Helm Operator pod created from the `git.config.data`
-| `git.config.secretName`                           | `None`                                               | The name of the kubernetes secret to store .gitconfig data created from the `git.config.data`
+| `git.config.secretName`                           | `None`                                               | The name of the kubernetes secret with .gitconfig data. It can be created manually or automatically using `git.config.createSecret` and `git.config.data`
+| `git.config.createSecret`                         | `true`                                               | If `true`, create the kubernetes secret with the value of `git.config.data`
 | `git.config.data`                                 | `None`                                               | The .gitconfig to be mounted into the home directory of the Helm Operator pod
 | `chartsSyncInterval`                              | `3m`                                                 | Period on which to reconcile the Helm releases with `HelmRelease` resources
 | `statusUpdateInterval`                            | `30s`                                                | Period on which to update the Helm release status in `HelmRelease` resources

--- a/chart/helm-operator/templates/gitconfig.yaml
+++ b/chart/helm-operator/templates/gitconfig.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.git.config.enabled -}}
+{{- if and .Values.git.config.enabled .Values.git.config.createSecret  -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -131,6 +131,7 @@ git:
   config:
     enabled: false
     secretName: ""
+    createSecret: true
     data: ""
     # data: |
     #   [credential "https://github.com"]


### PR DESCRIPTION
# Description

Adding a boolean option to not create the kubernetes secret when `git.config.enable` is set to true. This allows gitconfigs with actual secret information to be stored in kubernetes through a different pipeline rather than have actual secrets stored in the values section of the helm release (valid for autmated deploys where the deployment metadata is stored somewhere public)

As an example, for simplifying git auth in our infrastructure, we use a gitconfig like this to transparently authenticate all git operations:

```
url "https://<USERNAME>:<PASSWORD>@git.mydomain.com/"]
        insteadOf = https://git.mydomain.com/
        insteadOf = ssh://git@git.mydomain.com/
        insteadOf = git@git.mydomain.com:
```
