### PR TITLE
Add `terminationGracePeriodSeconds` value to Helm Operator Chart

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -77,6 +77,7 @@ chart and their default values.
 | `extraVolumeMounts`                               | `[]`                                                 | Extra volume mounts to be added to the Helm Operator pod(s)
 | `extraVolumes`                                    | `[]`                                                 | Extra volume to be added to the Helm Operator pod(s)
 | `priorityClassName`                               | `""`                                                 | Set priority class for Helm Operator
+| `terminationGracePeriodSeconds`                   | `""`                                                 | Set terminationGracePeriod in seconds for Helm Operator
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Helm Operator pod(s)
 | `podAnnotations`                                  | `{}`                                                 | Additional pod annotations
 | `podLabels`                                       | `{}`                                                 | Additional pod labels

--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -77,7 +77,7 @@ chart and their default values.
 | `extraVolumeMounts`                               | `[]`                                                 | Extra volume mounts to be added to the Helm Operator pod(s)
 | `extraVolumes`                                    | `[]`                                                 | Extra volume to be added to the Helm Operator pod(s)
 | `priorityClassName`                               | `""`                                                 | Set priority class for Helm Operator
-| `terminationGracePeriodSeconds`                   | `""`                                                 | Set terminationGracePeriod in seconds for Helm Operator
+| `terminationGracePeriodSeconds`                   | `300`                                                | Set terminationGracePeriod in seconds for Helm Operator
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Helm Operator pod(s)
 | `podAnnotations`                                  | `{}`                                                 | Additional pod annotations
 | `podLabels`                                       | `{}`                                                 | Additional pod labels

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       volumes:
       {{- if .Values.kube.config }}
       - name: config

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -233,6 +233,8 @@ hostAliases: {}
 
 priorityClassName: ""
 
+terminationGracePeriodSeconds: ""
+
 dashboards:
   # If enabled, helm-operator will create a configmap with a dashboard in json that's going to be picked up by grafana
   # See https://github.com/helm/charts/tree/master/stable/grafana#configuration - `sidecar.dashboards.enabled`

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -233,7 +233,7 @@ hostAliases: {}
 
 priorityClassName: ""
 
-terminationGracePeriodSeconds: ""
+terminationGracePeriodSeconds: 300
 
 dashboards:
   # If enabled, helm-operator will create a configmap with a dashboard in json that's going to be picked up by grafana

--- a/docs/helmrelease-guide/release-configuration.md
+++ b/docs/helmrelease-guide/release-configuration.md
@@ -131,7 +131,7 @@ spec:
 
 !!! warning
     When your chart requires a high non-default `timeout` value it is advised
-    to increase the `teriminationGracePeriod` on the Helm Operator pod to not
+    to increase the `terminationGracePeriod` on the Helm Operator pod to not
     end up with a release in a faulty state due to the operator receiving a
     `SIGKILL` signal during an upgrade.
 

--- a/docs/helmrelease-guide/rollbacks.md
+++ b/docs/helmrelease-guide/rollbacks.md
@@ -63,7 +63,7 @@ The definition of the listed keys is as follows:
 
 !!! warning
     When your chart requires a high non-default `timeout` value it is advised
-    to increase the `teriminationGracePeriod` on the Helm Operator pod to not
+    to increase the `terminationGracePeriod` on the Helm Operator pod to not
     end up with a release in a faulty state due to the operator receiving a
     `SIGKILL` signal during an upgrade.
 


### PR DESCRIPTION
This is necessary when timeout may be set to a higher value to help ensure that Helm Operator isnt killed before its done waiting for an operation to finish. Also correct spelling.

As outlined here: https://github.com/fluxcd/helm-operator/blob/master/docs/helmrelease-guide/release-configuration.md#configuring-the-timeout