### PR TITLE
Support setting config and known_hosts together

### DIFF
--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
           items:
             - key: {{ .Values.git.ssh.configMapKey | default "config" }}
               path: config
+            - key: known_hosts
+              path: known_hosts  
           defaultMode: 0400
       {{- end }}
       - name: git-key


### PR DESCRIPTION
Flux chart support passing known_hosts and config together which doesnot seem to be working here. We could pass only known_hosts or ssh config at a time. This commit add the support for passing using ssh/config and ssh/known_hosts together via the configmap which usually will be set in the flux chart.

<!--
# Notice

The Helm Operator is in maintenance mode, and it will take a bit
longer until we get around to issues and PRs.
      
For more information, and details about the Helm Operator's future,
see: https://github.com/fluxcd/helm-operator/issues/546 

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
