### PR TITLE
Remove the query string from the CleanURL

### DIFF
--- a/pkg/apis/helm.fluxcd.io/v1/types_helmrelease.go
+++ b/pkg/apis/helm.fluxcd.io/v1/types_helmrelease.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -226,11 +227,16 @@ type RepoChartSource struct {
 	ChartPullSecret *LocalObjectReference `json:"chartPullSecret,omitempty"`
 }
 
-// CleanRepoURL returns the RepoURL but ensures it ends with a trailing
-// slash.
+// CleanRepoURL returns the RepoURL but removes the query string and ensures
+// it ends with a trailing slash.
 func (s RepoChartSource) CleanRepoURL() string {
-	cleanURL := strings.TrimRight(s.RepoURL, "/")
-	return cleanURL + "/"
+	cleanURL, err := url.Parse(s.RepoURL)
+	if err != nil {
+		return strings.TrimSuffix(s.RepoURL, "/") + "/"
+	}
+	cleanURL.Path = strings.TrimSuffix(cleanURL.Path, "/") + "/"
+	cleanURL.RawQuery = ""
+	return cleanURL.String()
 }
 
 type ValuesFromSource struct {


### PR DESCRIPTION
We are using Azure Blob storage as a private Helm repository. As described [here](https://cwienczek.com/2017/10/setting-up-secure-helm-chart-repository-on-azure-blob-storage/). This breaks in helm-operator because the SAS token makes the cache directory too long and it fails with the following message:

```
synchronization of release 'demo' in namespace 'default' failed: failed to prepare chart for release: chart unavailable: mkdir /tmp/v3/[LONG FILE NAME]: file name too long
```

This PR strips the query string from the repo url that is used for caching so that:
1. If the authentication token changes the same cache can still be used.
2. The directory name is shorter