### PR TITLE
to prevent incorrect helm reconciliation, sync chart mirror beforehand

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -293,7 +293,7 @@ func main() {
 	// _before_ starting it or else the cache sync seems to hang at
 	// random
 	opr := operator.New(log.With(logger, "component", "operator"),
-		*logReleaseDiffs, kubeClient, hrInformer, queue, rel)
+		*logReleaseDiffs, kubeClient, hrInformer, queue, rel, gitChartSync)
 	go ifInformerFactory.Start(shutdown)
 
 	// wait for the caches to be synced before starting _any_ workers


### PR DESCRIPTION
This PR fixes the issue observed in #562 
if there is a change in the chartsource (ref change, eg), its possible that the mirror's ref-sha be obsolete w.r.t. upstream repo's ref-sha. To avoid spurious deploy, mirror is synced before doing helm reconciliation.

CHANGELOG :
operator: incase of a helmrelease's chartsource update, to prevent incorrect helm reconciliation, sync chart mirror beforehand
