### PR TITLE
Sync chart mirror on chart spec change to prevent incorrect reconciliation

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -293,7 +293,7 @@ func main() {
 	// _before_ starting it or else the cache sync seems to hang at
 	// random
 	opr := operator.New(log.With(logger, "component", "operator"),
-		*logReleaseDiffs, kubeClient, hrInformer, queue, rel)
+		*logReleaseDiffs, kubeClient, hrInformer, queue, rel, gitChartSync)
 	go ifInformerFactory.Start(shutdown)
 
 	// wait for the caches to be synced before starting _any_ workers

--- a/pkg/chartsync/git.go
+++ b/pkg/chartsync/git.go
@@ -203,6 +203,21 @@ func (c *GitChartSync) Delete(hr *v1.HelmRelease) bool {
 	return ok
 }
 
+// SyncMirror instructs the helmrelease's git mirror to sync from its upstream
+func (c *GitChartSync) SyncMirror(hr *v1.HelmRelease) error {
+	mirror := mirrorName(hr)
+	c.logger.Log("info", "starting sync of git mirror", "mirror", mirror)
+	repo, ok := c.mirrors.Get(mirror)
+	if !ok {
+		return ChartNotReadyError{ErrNoMirror}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.config.GitTimeout)
+	repo.Refresh(ctx)
+	cancel()
+	c.logger.Log("info", "finished syncing git mirror", "mirror", mirror)
+	return nil
+}
+
 // SyncMirrors instructs all git mirrors to sync from their respective
 // upstreams.
 func (c *GitChartSync) SyncMirrors() {


### PR DESCRIPTION
This PR fixes the issue observed in #562
if there is a change in the chartsource (ref change, eg), its possible that the mirror's ref-sha be obsolete w.r.t. upstream repo's ref-sha. To avoid spurious deploy, mirror is synced before doing helm reconciliation.

CHANGELOG :
Bug fixes:
operator: incase of a helmrelease's chartsource update, to prevent incorrect helm reconciliation, sync chart mirror beforehand