### PR TITLE
Tighten pod security policy and allow custom role rules

### DIFF
--- a/chart/helm-operator/templates/_helpers.tpl
+++ b/chart/helm-operator/templates/_helpers.tpl
@@ -47,11 +47,34 @@ Create the name of the cluster role to use.
 */}}
 {{- define "helm-operator.clusterRoleName" -}}
 {{- if .Values.clusterRole.create -}}
-    {{ default (include "helm-operator.fullname" .) .Values.clusterRole.name }}
+{{- $name := printf "%s-%s" .Release.Namespace (include "helm-operator.fullname" .) -}}
+{{ default $name .Values.clusterRole.name }}
 {{- else -}}
-    {{ default "default" .Values.clusterRole.name }}
+{{ default "default" .Values.clusterRole.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create cluster wide name for psp cluster role (includes the current namespace)
+*/}}
+{{- define "helm-operator.clusterrole.psp.name" -}}
+{{- printf "%s-%s-%s" .Release.Namespace (include "helm-operator.fullname" .) "psp" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create cluster wide name for psp cluster role (includes the current namespace)
+*/}}
+{{- define "helm-operator.rolebinding.psp.name" -}}
+{{- printf "%s-%s" (include "helm-operator.fullname" .) "psp" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create cluster wide name for psp (includes the current namespace)
+*/}}
+{{- define "helm-operator.psp.name" -}}
+{{- printf "%s-%s" .Release.Namespace (include "helm-operator.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 
 {{/*
 Create a custom repositories.yaml for Helm.

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -352,6 +352,5 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
       securityContext:
-        fsGroup: 1
         supplementalGroups:
         - 1

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -294,6 +294,11 @@ spec:
       {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       {{- if .Values.tillerSidecar.enabled }}
       - name: tiller
         image: "{{ .Values.tillerSidecar.image.repository }}:{{ .Values.tillerSidecar.image.tag }}"
@@ -346,3 +351,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      securityContext:
+        fsGroup: 1
+        supplementalGroups:
+        - 1

--- a/chart/helm-operator/templates/psp.yaml
+++ b/chart/helm-operator/templates/psp.yaml
@@ -2,38 +2,39 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "helm-operator.fullname" . }}
+  name: {{ template "helm-operator.psp.name" . }}
   labels:
     app: {{ include "helm-operator.name" . }}
     chart: {{ include "helm-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
-  privileged: false
-  hostIPC: false
-  hostNetwork: false
-  hostPID: false
-  readOnlyRootFilesystem: false
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-    - '*'
+  allowPrivilegeEscalation: false
   fsGroup:
-    rule: RunAsAny
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
   runAsUser:
     rule: RunAsAny
   seLinux:
     rule: RunAsAny
   supplementalGroups:
-    rule: RunAsAny
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
   volumes:
-    - '*'
+  - configMap
+  - emptyDir
+  - secret
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "helm-operator.fullname" . }}-psp
+  name: {{ template "helm-operator.clusterrole.psp.name" . }}
   labels:
     app: {{ include "helm-operator.name" . }}
     chart: {{ include "helm-operator.chart" . }}
@@ -44,12 +45,12 @@ rules:
       resources: ['podsecuritypolicies']
       verbs:     ['use']
       resourceNames:
-        - {{ template "helm-operator.fullname" . }}
+        - {{ template "helm-operator.psp.name" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-    name: {{ template "helm-operator.fullname" . }}-psp
+    name: {{ template "helm-operator.rolebinding.psp.name" . }}
     labels:
         app: {{ include "helm-operator.name" . }}
         chart: {{ include "helm-operator.chart" . }}
@@ -58,7 +59,7 @@ metadata:
 roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: {{ template "helm-operator.fullname" . }}-psp
+    name: {{ template "helm-operator.clusterrole.psp.name" . }}
 subjects:
     - kind: ServiceAccount
       name: {{ template "helm-operator.serviceAccountName" . }}

--- a/chart/helm-operator/templates/psp.yaml
+++ b/chart/helm-operator/templates/psp.yaml
@@ -11,10 +11,7 @@ metadata:
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
+    rule: RunAsAny
   requiredDropCapabilities:
   - ALL
   runAsUser:

--- a/chart/helm-operator/templates/rbac-role.yaml
+++ b/chart/helm-operator/templates/rbac-role.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (eq .Values.clusterRole.create false) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "helm-operator.fullname" . }}
@@ -10,14 +10,19 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
+  # Allow access to the CRD
+  - apiGroups: ["helm.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["helm.fluxcd.io"]
+    resources: ["helmreleases/status"]
+    verbs: ["create", "patch", "update"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+{{ .Values.rbac.rules | toYaml | indent 2 }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "helm-operator.fullname" . }}

--- a/chart/helm-operator/templates/rbac.yaml
+++ b/chart/helm-operator/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.create (eq .Values.clusterRole.create true) -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "helm-operator.clusterRoleName" . }}
@@ -9,18 +9,19 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - nonResourceURLs:
-      - '*'
-    verbs:
-      - '*'
+  # Allow access to the CRD
+  - apiGroups: ["helm.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["helm.fluxcd.io"]
+    resources: ["helmreleases/status"]
+    verbs: ["create", "patch", "update"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+{{ .Values.rbac.rules | toYaml | indent 2 }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "helm-operator.clusterRoleName" . }}

--- a/chart/helm-operator/values.yaml
+++ b/chart/helm-operator/values.yaml
@@ -141,6 +141,11 @@ rbac:
   create: true
   # Specifies whether PSP resources should be created
   pspEnabled: false
+  # Specifies the role rules to apply to the service account running Flux
+  rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ['*']
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Thank you very much for a great product. I know the current Helm Operator version is in maintenance mode and it may not make sense to do this change. However, as we have done it I thought we should give you the opportunity to include it upstream should you so decide.

The PR tightens the pod security policy for Helm Operator a bit and also adds security context to the pod specifications to make sure the most correct pod security policy is chosen (see [Policy Order](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#policy-order)). Furthermore the PR will make the set of rules configured for the namespace or cluster wide role configurable making it possible to tighten the permissions applied to Flux. The default is complete access as it is in the current chart version.

Note the cluster wide objects has been prefixed with the namespace as Helm v3 works with release names as "namespaced" hence if Flux were to be deployed into multiple namespaces using the same release name there could be a clash in the naming of non-namespaced objects.