### PR TITLE
Added custom yaml anchors

### DIFF
--- a/chart/helm-operator/README.md
+++ b/chart/helm-operator/README.md
@@ -156,6 +156,8 @@ chart and their default values.
 | `containerSecurityContext.helmOperator`           | `{}`                                                 | Adding `securityContext` options to the helm operator container
 | `containerSecurityContext.tiller`                 | `{}`                                                 | Adding `securityContext` options to the tiller container
 | `sidecarContainers`                               | `{}`                                                 | Sidecar containers along with the specifications.
+| `anchorPattern`                                   | `""`                                                 | A pattern for string substitution using an yaml anchor like syntax 
+
 
 ## How-to
 
@@ -328,6 +330,44 @@ spec:
     replicaCount: 1
 EOF
 ```
+
+### Use custom anchors
+Perhaps you use a single config map for multiple services, it might look something like this:
+```
+...
+data:
+  prometheus.yaml: |
+    server:
+      global:
+        external_labels:
+          cluster: kubernetes-sandbox-us-east-2
+  splunk.yaml: |
+    global:
+      region: us-east-2
+      clusterName: kubernetes-sandbox-us-east-2
+      splunk:
+        hec:
+          indexName: my-index
+      kubernetes:
+        clusterName: kubernetes-sandbox-us-east-2
+...
+```
+
+With custom anchors, given a string such as "^&|swap-" it can look like
+```
+...
+data:
+  global.yaml: |-
+    clusterName: ^&cluster_name kubernetes-sandbox-us-east-2
+  splunk.yaml: |-
+    region: ^&region us-east-2
+    index: ^&index my-index
+...
+```
+
+Anywhere in your flux helm resource values you can simply define swap-cluster_name and that line will be swaped with it's reference. Strings are arbitrary, and can be almost anything as long as it does not conflict with the yaml spec (starting with & for example would be problematic).
+
+
 
 ### Uninstall
 

--- a/chart/helm-operator/templates/deployment.yaml
+++ b/chart/helm-operator/templates/deployment.yaml
@@ -240,6 +240,9 @@ spec:
         {{- if .Values.kube.config }}
         - --kubeconfig=/root/.kube/config
         {{- end }}
+        {{- if .Values.anchorPattern }}
+        - --anchor-pattern={{ .Values.anchorPattern }}
+        {{- end }}
         {{- if .Values.logFormat }}
         - --log-format={{ .Values.logFormat }}
         {{- end }}

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -77,6 +77,8 @@ var (
 
 	enabledHelmVersions *[]string
 	defaultHelmVersion  *string
+
+	anchorPattern *string
 )
 
 const (
@@ -134,6 +136,8 @@ func init() {
 	versionedHelmRepositoryIndexes = fs.StringSlice("helm-repository-import", nil, "Targeted version and the path of the Helm repository index to import, i.e. v3:/tmp/v3/index.yaml,v2:/tmp/v2/index.yaml")
 
 	enabledHelmVersions = fs.StringSlice("enabled-helm-versions", []string{helmv2.VERSION, helmv3.VERSION}, "Helm versions supported by this operator instance")
+
+	anchorPattern = fs.String("anchor-pattern", "", `[reference pattern|dereference pattern] e.g. "^&|swap-". Custom yaml anchors for simple string substitution`)
 }
 
 func main() {
@@ -284,7 +288,7 @@ func main() {
 		kubeClient.CoreV1(),
 		ifClient.HelmV1(),
 		gitChartSync,
-		release.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, DefaultHelmVersion: *defaultHelmVersion},
+		release.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, DefaultHelmVersion: *defaultHelmVersion, AnchorPattern: *anchorPattern},
 		converter,
 	)
 

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -25,6 +25,7 @@ type Config struct {
 	UpdateDeps         bool
 	LogDiffs           bool
 	DefaultHelmVersion string
+	AnchorPattern      string
 }
 
 // WithDefaults sets the default values for the release config.
@@ -93,7 +94,7 @@ func (r *Release) Sync(hr *apiV1.HelmRelease) (err error) {
 	}
 
 	var values []byte
-	values, err = composeValues(r.coreV1Client, hr, chart.chartPath)
+	values, err = composeValues(r.coreV1Client, hr, chart.chartPath, r.config.AnchorPattern)
 	if err != nil {
 		status.SetStatusPhase(r.hrClient.HelmReleases(hr.GetTargetNamespace()), hr, apiV1.HelmReleasePhaseFailed)
 		err = fmt.Errorf("failed to compose values for release: %w", err)


### PR DESCRIPTION
## Enhancement
- Added custom anchor syntax for simple string substitution

First, I know this project is deprecated. This will help me get off of it. I have to unify multiple platforms between onprem and the cloud. This gives me some flexibility to do that. Once things are stable I can start the push to flux v2. I don't have the time or bandwidth to make a bunch of architectural changes right now when this serves my needs. 

I made every attempt to follow all the guidelines, I intentionally made separate methods that have no impact on existing ones. If you don't pass an anchor string, absolutely nothing happens or changes. You have a method that walks the values map, I could have integrated there, I intentionally chose not to. Same with tests. I could have integrated into the struct and flow you had, but I made another (very similar) method that tests just my addition (both success and failure).

The code is clean. It's a single pass, with some strings being swapped out using references. Overall I'm very happy with this. I added documentation etc. I think it's a lot of value for very little risk and it's my first attempt at contribution to a major project so I'm hoping we can merge this