### PR TITLE
Verbose error on missing variable for e2e if HELM_VERSION is not set

### DIFF
--- a/test/e2e/run.bash
+++ b/test/e2e/run.bash
@@ -19,6 +19,11 @@ BATS_EXTRA_ARGS=""
 source "${E2E_DIR}/lib/defer.bash"
 trap run_deferred EXIT
 
+if [[ -z "$HELM_VERSION" ]]; then
+  echo "HELM_VERSION not set. Valid v2, v3. See $ROOT_DIR/docs/contributing/building.md"
+  exit 1
+fi
+
 function install_kind() {
   if [ ! -f "${KIND_CACHE_PATH}" ]; then
     echo '>>> Downloading Kind'


### PR DESCRIPTION
It's 4 lines that can save some time and energy for people that might not be familiar with the process. Just an error message for e2e 