### PR TITLE
Add CRD note for 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 This is the second minor release, it adds support for Helm tests and
 v2 to v3 release conversions, and includes a variety of bug fixes.
 
+NOTE: Make sure to update the CRD when upgrading from a previous version as they have been changed in this release.
+
 ### Bug fixes
 
  - metrics: use release name and namespace in `release_condition_info`


### PR DESCRIPTION
When we upgraded from 1.1.0 to 1.2.0 we missed that the CRD had been updated, and that caused some strange behavior (releases where constantly upgraded even when no changes had been made). This could hopefully help others from missing to update the CRD.

