### PR TITLE
fix(pkg/helm): Use `New` to create a complete `EnvSettings` struct

### DIFF
--- a/chart/helm-operator/Chart.yaml
+++ b/chart/helm-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.4.0"
-version: 1.2.0
+version: 1.4.0
 kubeVersion: ">=1.16.0-0"
 name: helm-operator
 description: Flux Helm Operator is a CRD controller for declarative helming

--- a/pkg/helm/v3/helm.go
+++ b/pkg/helm/v3/helm.go
@@ -123,9 +123,9 @@ func newStorageDriver(client *kubernetes.Clientset, logFunc infoLogFunc, namespa
 }
 
 func getterProviders() getter.Providers {
-	return getter.All(&cli.EnvSettings{
-		RepositoryConfig: repositoryConfig,
-		RepositoryCache:  repositoryCache,
-		PluginsDirectory: pluginsDir,
-	})
+	settings := cli.New()
+	settings.RepositoryConfig = repositoryConfig
+	settings.RepositoryCache = repositoryCache
+	settings.PluginsDirectory = pluginsDir
+	return getter.All(settings)
 }


### PR DESCRIPTION
This avoids invalid memory addresses from uninitialised fields when initialising plugin environments.

Upgrading Helm [brought in this change](https://github.com/helm/helm/commit/4a0dfbe53b2191e09a7034ce97e4caf84989d6db#diff-f3e6a920d4f94bb29be3f3a1eb084f24R128) which relies on config being set to a valid reference. Calling `New` ensures that it is. :)


Sorry this is pulled into the chart-bump-1.4.0 branch, I was also testing the charts and haven't got time right now to test on master. I can clean up the commit etc tomorrow, just wanted to document this.

Was seeing this error in the 1.4.0-rc1:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa8 pc=0x16340a2]

goroutine 1 [running]:
k8s.io/cli-runtime/pkg/genericclioptions.(*ConfigFlags).ToRawKubeConfigLoader(0x0, 0x93e02f3e83bd8994, 0x0)
/home/circleci/go/src/github.com/fluxcd/helm-operator/vendor/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go:122 +0x22
helm.sh/helm/v3/pkg/cli.(*EnvSettings).Namespace(0xc0002b0000, 0xc00037d0e0, 0x1d0b1a9)
/home/circleci/go/src/github.com/fluxcd/helm-operator/vendor/helm.sh/helm/v3/pkg/cli/environment.go:177 +0x2f
helm.sh/helm/v3/pkg/cli.(*EnvSettings).EnvVars(0xc0002b0000, 0x160)
/home/circleci/go/src/github.com/fluxcd/helm-operator/vendor/helm.sh/helm/v3/pkg/cli/environment.go:158 +0x5a1
helm.sh/helm/v3/pkg/plugin.SetupPluginEnv(0xc0002b0000, 0xc00003522e, 0x2, 0xc000445ac0, 0x2b)
/home/circleci/go/src/github.com/fluxcd/helm-operator/vendor/helm.sh/helm/v3/pkg/plugin/plugin.go:276 +0x40
helm.sh/helm/v3/pkg/getter.(*pluginGetter).Get(0xc0000ed450, 0xc000445d80, 0x2a, 0xc0003ff1c0, 0x4, 0x4, 0xc000630040, 0x1752278, 0x1ceeba1)
/home/circleci/go/src/github.com/fluxcd/helm-operator/vendor/helm.sh/helm/v3/pkg/getter/plugingetter.go:73 +0x290
helm.sh/helm/v3/pkg/repo.(*ChartRepository).DownloadIndexFile(0xc000095a90, 0xc000095a90, 0x0, 0x0, 0x0)
/home/circleci/go/src/github.com/fluxcd/helm-operator/vendor/helm.sh/helm/v3/pkg/repo/chartrepo.go:127 +0x330
github.com/fluxcd/helm-operator/pkg/helm/v3.(*HelmV3).RepositoryImport(0xc00034b460, 0xc0002bcd53, 0x28, 0x0, 0x0)
/home/circleci/go/src/github.com/fluxcd/helm-operator/pkg/helm/v3/repository.go:111 +0x460
main.main()
/home/circleci/go/src/github.com/fluxcd/helm-operator/cmd/helm-operator/main.go:255 +0x235a
```