### PR TITLE
disable chart linting

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -17,3 +17,4 @@ jobs:
           owner: fluxcd
           repository: charts
           branch: gh-pages
+          linting: off


### PR DESCRIPTION
Since we are not using the CRD v1 until 1.4.0, linting fails. The linter can be disabled in the release configuration for chart.