### PR TITLE
Fix quoting of password etc in helm-operator chart

### DIFF
--- a/chart/helm-operator/templates/_helpers.tpl
+++ b/chart/helm-operator/templates/_helpers.tpl
@@ -64,11 +64,11 @@ repositories:
 - name: {{ required "Please specify a name for the Helm repo" .name }}
   url: {{ required "Please specify a URL for the Helm repo" .url }}
   cache: /var/fluxd/helm/repository/cache/{{ .name }}-index.yaml
-  caFile: "{{ .caFile | default "" }}"
-  certFile: "{{ .certFile | default "" }}"
-  keyFile: "{{ .keyFile | default "" }}"
-  password: "{{ .password | default "" }}"
-  username: "{{ .username | default "" }}"
+  caFile: {{ .caFile | default "" | quote }}
+  certFile: {{ .certFile | default "" | quote }}
+  keyFile: {{ .keyFile | default "" | quote }}
+  password: {{ .password | default "" | quote }}
+  username: {{ .username | default "" | quote }}
 {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Values in the generated repositories.yaml are now correctly quoted

<!--
# ---- NOTICE -----

Helm Operator v1 is in maintenance mode and Flux v2 is getting
closer to GA. If you want to learn about migrating to Flux v2,
please review <https://github.com/fluxcd/flux2/discussions/413>.

As it will take longer until we get around to issues and PRs in
Helm Operator v1, we strongly recommend that you start
familiarising yourself with Flux v2: <https://toolkit.fluxcd.io/>

This means that new features will only be added after very careful
consideration, if at all. Refer to the links above for more detail.

# ---- END NOTICE -----

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->

Fixes #629.

Output from the `values.yaml` given in that issue is now:
```yaml
apiVersion: v1
generated: 0001-01-01T00:00:00Z
repositories:
- name: fluxcd
  url: https://charts.fluxcd.io
  cache: /var/fluxd/helm/repository/cache/fluxcd-index.yaml
  caFile: ""
  certFile: ""
  keyFile: ""
  password: "this-\\-is-a-literal-backslash"
  username: "dimbleby"
```
which is correctly escaped