### PR TITLE
replace deprecated io/ioutil in packages

### DIFF
--- a/internal/lockedfile/lockedfile.go
+++ b/internal/lockedfile/lockedfile.go
@@ -9,7 +9,6 @@ package lockedfile
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 )
@@ -103,7 +102,7 @@ func Read(name string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 // Write opens the named file (creating it with the given permissions if needed),
@@ -135,7 +134,7 @@ func Transform(name string, t func([]byte) ([]byte, error)) (err error) {
 	}
 	defer f.Close()
 
-	old, err := ioutil.ReadAll(f)
+	old, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -43,7 +42,7 @@ func main() {
 			os.Exit(1)
 		}
 		for fileName, contents := range manifests {
-			if err := ioutil.WriteFile(fileName, contents, 0600); err != nil {
+			if err := os.WriteFile(fileName, contents, 0600); err != nil {
 				fmt.Fprintf(os.Stderr, "error: failed to write deploy file %s: %s\n", fileName, err)
 				os.Exit(1)
 			}

--- a/pkg/install/generated_templates.gogen.go
+++ b/pkg/install/generated_templates.gogen.go
@@ -7,7 +7,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	pathpkg "path"
@@ -125,7 +124,7 @@ func (f *vfsgen۰CompressedFile) Read(p []byte) (n int, err error) {
 	}
 	if f.grPos < f.seekPos {
 		// Fast-forward.
-		_, err = io.CopyN(ioutil.Discard, f.gr, f.seekPos-f.grPos)
+		_, err = io.CopyN(io.Discard, f.gr, f.seekPos-f.grPos)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -42,7 +41,7 @@ func FillInTemplates(params TemplateParameters) (map[string][]byte, error) {
 		if info.IsDir() {
 			return nil
 		}
-		manifestTemplateBytes, err := ioutil.ReadAll(rs)
+		manifestTemplateBytes, err := io.ReadAll(rs)
 		if err != nil {
 			return fmt.Errorf("cannot read embedded file %q: %s", info.Name(), err)
 		}

--- a/pkg/release/values.go
+++ b/pkg/release/values.go
@@ -3,9 +3,10 @@ package release
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -145,7 +146,7 @@ func readURL(URL string) ([]byte, error) {
 	}
 	switch resp.StatusCode {
 	case http.StatusOK:
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return []byte{}, err
 		}
@@ -157,7 +158,7 @@ func readURL(URL string) ([]byte, error) {
 
 // readLocalChartFile attempts to read a file from the chart path.
 func readLocalChartFile(filePath string) ([]byte, error) {
-	f, err := ioutil.ReadFile(filePath)
+	f, err := os.ReadFile(filePath)
 	if err != nil {
 		return []byte{}, err
 	}


### PR DESCRIPTION
<!--
# ---- NOTICE -----

Helm Operator v1 is in maintenance mode and Flux v2 is getting
closer to GA. If you want to learn about migrating to Flux v2,
please review <https://github.com/fluxcd/flux2/discussions/413>.

As it will take longer until we get around to issues and PRs in
Helm Operator v1, we strongly recommend that you start
familiarising yourself with Flux v2: <https://toolkit.fluxcd.io/>

This means that new features will only be added after very careful
consideration, if at all. Refer to the links above for more detail.

# ---- END NOTICE -----

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->

This PR is to replace the io/ioutil package which has been deprecated , the replacement has been done on all the various packages used in the helm operator
