### PR TITLE
Updated deploy/rbac.yaml ClusterRole and ClusterRoleBinding to V1

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   name: helm-operator
   namespace: flux
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -20,7 +20,7 @@ rules:
   - nonResourceURLs: ['*']
     verbs: ['*']
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:


### PR DESCRIPTION
Bumping deploy/rbac.yaml ClusterRole and ClusterRoleBinding to V1. It's already updated on v1.4.1 in the chart itself. 

<!--
# ---- NOTICE -----

Helm Operator v1 is in maintenance mode and Flux v2 is getting
closer to GA. If you want to learn about migrating to Flux v2,
please review <https://github.com/fluxcd/flux2/discussions/413>.

As it will take longer until we get around to issues and PRs in
Helm Operator v1, we strongly recommend that you start
familiarising yourself with Flux v2: <https://toolkit.fluxcd.io/>

This means that new features will only be added after very careful
consideration, if at all. Refer to the links above for more detail.

# ---- END NOTICE -----

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/fluxcd/helm-operator/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md file in the top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
