### PR TITLE
Update releasing doc

### DIFF
--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -68,7 +68,7 @@ change.
 
 8. [Create a release in GitHub](https://github.com/fluxcd/helm-operator/releases/new)
 
-    Use a tag name as explained above; semver (`1.2.3`).
+    Use a tag name as explained above; semver (`v1.2.3`).
 
     Copy and paste the changelog entry. You may need to remove newlines that have been inserted by your editor, so that it wraps nicely.
 


### PR DESCRIPTION
The build process require that the release tag be prefixed with `v` as per:

https://github.com/fluxcd/helm-operator/blob/cc24dbef9a322758ca144409a71e381d099fe2bd/.circleci/config.yml#L104